### PR TITLE
Initial basic functionality of short form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ composer.phar
 # Commit your application's lock file http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 # composer.lock
+node_modules
+bower_components

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
 
 install:
   - composer install --no-interaction --prefer-source
+  - npm install
+  - bower install
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test_asu_rfi root '' localhost $WP_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ php:
   - 7.0
 
 env:
-  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=4.6 WP_MULTISITE=0
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 
 install:
   - composer install --no-interaction --prefer-source
-  - npm install
+  - npm install bower -g
   - bower install
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,20 @@ WordPress plugin to submit Request For Information requests into Salesforce
 * [GitHub Updater WordPress Plugin](https://github.com/afragen/github-updater)
 
 
+# Site Settings
+**source_id** you need to uptain a orignal source identifier from the [ASU Enrollment Services Department](mailto:ecomm@asu.edu) for your college or department.
+
+![screen shot 2016-12-13 at 12 43 24 pm](https://cloud.githubusercontent.com/assets/295804/21156084/c728ccae-c131-11e6-8e0f-7cbc1a6e3db6.png)
+
+
 # Shortcodes
 
-* `[asu-rfi-form]` - For displaying an Request For Information form.
+`[asu-rfi-form]` - For displaying an Request For Information form.
+* attributes:
+   *     type = 'full' or leave blank for the default simple form
+   *     degree_level = 'ugrad' or 'grad' Default is 'ugrad'
+   *     test_mode = 'test' or leave blank for the default production
+   *     source_id = integer site identifier (issued by Enrollment services department) will default to site wide setting
+
+![screen shot 2016-12-12 at 3 38 20 pm](https://cloud.githubusercontent.com/assets/295804/21119802/6a034bc2-c081-11e6-8d86-c5d55b0efc9c.png)
 

--- a/assets/css/asu-rfi.css
+++ b/assets/css/asu-rfi.css
@@ -1,0 +1,5 @@
+.honey {
+  display: none;
+}
+
+/*.required { }*/

--- a/assets/css/asu-rfi.css
+++ b/assets/css/asu-rfi.css
@@ -2,4 +2,7 @@
   display: none;
 }
 
-/*.required { }*/
+.required label:after { 
+  content: " (required)";
+  color: red;
+}

--- a/assets/css/asu-rfi.css
+++ b/assets/css/asu-rfi.css
@@ -2,7 +2,14 @@
   display: none;
 }
 
+/*
 .required label:after { 
-  content: " (required)";
+  content: " (Required)";
   color: red;
+}
+*/
+
+.optional label:before { 
+  content: " (Optional) ";
+  color: #8c7c7c;
 }

--- a/asu-rfi-wordpress-plugin.php
+++ b/asu-rfi-wordpress-plugin.php
@@ -19,6 +19,8 @@ if ( ! function_exists( 'add_filter' ) ) {
   exit();
 }
 
+define( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION', '0.0.1' );
+
 require __DIR__ . '/vendor/autoload.php';
 
 $registry = new \Honeycomb\Services\Register();

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "asu-rfi-wordpress-plugin",
+  "description": "ASU Request For Information forms for WordPress",
+  "main": "asu-rfi-wordpress-plugin.php",
+  "authors": [
+    "GIOS ASU"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/gios-asu/ASU-RFI-WordPress-Plugin",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery-validation": "^1.16.0"
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
   "license": "MIT",
   "require": {
     "php": ">=5.5",
-    "gios-asu/nectary": "^0.1.9",
-    "gios-asu/honeycomb": "^1.0.0",
+    "gios-asu/nectary": "^0.2.2",
+    "gios-asu/honeycomb": "^1.0.3",
     "phpxmlrpc/phpxmlrpc": "^4.0",
     "phine/country": "^1.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "gios-asu/nectary": "^0.1.9",
     "gios-asu/honeycomb": "^1.0.0",
     "phpxmlrpc/phpxmlrpc": "^4.0",
-    "mledoze/countries": "^1.8"
+    "phine/country": "^1.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,9 @@
   "require": {
     "php": ">=5.5",
     "gios-asu/nectary": "^0.1.9",
-    "gios-asu/honeycomb": "^1.0.0"
+    "gios-asu/honeycomb": "^1.0.0",
+    "phpxmlrpc/phpxmlrpc": "^4.0",
+    "mledoze/countries": "^1.8"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "85635173a1649afbef99ad18eb68512c",
-    "content-hash": "ef856f634f6d96e324025063353469e4",
+    "hash": "029f82f655f81be8bf93782486596c02",
+    "content-hash": "62e9c8acbd74fd27017519b14a4a35f0",
     "packages": [
         {
             "name": "coduo/php-humanizer",
@@ -147,6 +147,150 @@
             "time": "2016-09-30 21:49:54"
         },
         {
+            "name": "mledoze/countries",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mledoze/countries.git",
+                "reference": "c212082894e48e8be123dad5dea7d9e6abc0c1b9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://github.com/mledoze/countries/archive/master.zip",
+                "reference": "c212082894e48e8be123dad5dea7d9e6abc0c1b9",
+                "shasum": null
+            },
+            "require": {
+                "php": ">=5.4",
+                "symfony/console": "^2.7|^3.0",
+                "symfony/yaml": "^2.7|^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MLD\\": "src/MLD"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Open Database License"
+            ],
+            "authors": [
+                {
+                    "name": "Mohammed Le Doze"
+                }
+            ],
+            "description": "World countries in JSON, CSV, XML and Yaml",
+            "homepage": "https://mledoze.github.io/countries/",
+            "keywords": [
+                "countries",
+                "csv",
+                "json",
+                "world",
+                "xml",
+                "yaml"
+            ],
+            "time": "2016-09-01 09:41:00"
+        },
+        {
+            "name": "phpxmlrpc/phpxmlrpc",
+            "version": "4.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/gggeek/phpxmlrpc.git",
+                "reference": "e7b08a72aecd879884bc85988640cf49302ce041"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/gggeek/phpxmlrpc/zipball/e7b08a72aecd879884bc85988640cf49302ce041",
+                "reference": "e7b08a72aecd879884bc85988640cf49302ce041",
+                "shasum": ""
+            },
+            "require": {
+                "ext-xml": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "dev-master",
+                "docbook/docbook-xsl": "~1.78",
+                "ext-curl": "*",
+                "ext-mbstring": "*",
+                "indeyets/pake": "~1.99",
+                "phpunit/phpunit": ">=4.0.0",
+                "phpunit/phpunit-selenium": "*",
+                "sami/sami": "~3.1"
+            },
+            "suggest": {
+                "ext-curl": "Needed for HTTPS and HTTP 1.1 support, NTLM Auth etc...",
+                "ext-mbstring": "Needed to allow reception of requests/responses in character sets other than ASCII,LATIN-1,UTF-8",
+                "ext-zlib": "Needed for sending compressed requests and receiving compressed responses, if cURL is not available"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpXmlRpc\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A php library for building xmlrpc clients and servers",
+            "homepage": "http://gggeek.github.io/phpxmlrpc/",
+            "keywords": [
+                "webservices",
+                "xmlrpc"
+            ],
+            "time": "2016-10-01 12:29:37"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10 12:19:37"
+        },
+        {
             "name": "symfony/config",
             "version": "v3.1.5",
             "source": {
@@ -198,6 +342,124 @@
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
             "time": "2016-09-25 08:27:07"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "6cb0872fb57b38b3b09ff213c21ed693956b9eb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/6cb0872fb57b38b3b09ff213c21ed693956b9eb0",
+                "reference": "6cb0872fb57b38b3b09ff213c21ed693956b9eb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/debug": "~2.8|~3.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/process": "~2.8|~3.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-28 00:11:12"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
+                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+            },
+            "require-dev": {
+                "symfony/class-loader": "~2.8|~3.0",
+                "symfony/http-kernel": "~2.8|~3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-06 11:02:40"
         },
         {
             "name": "symfony/filesystem",
@@ -1194,53 +1456,6 @@
             "time": "2015-10-02 06:51:40"
         },
         {
-            "name": "psr/log",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "time": "2016-10-10 12:19:37"
-        },
-        {
             "name": "satooshi/php-coveralls",
             "version": "v1.0.1",
             "source": {
@@ -1747,124 +1962,6 @@
                 "standards"
             ],
             "time": "2016-09-01 23:53:02"
-        },
-        {
-            "name": "symfony/console",
-            "version": "v3.1.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "6cb0872fb57b38b3b09ff213c21ed693956b9eb0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6cb0872fb57b38b3b09ff213c21ed693956b9eb0",
-                "reference": "6cb0872fb57b38b3b09ff213c21ed693956b9eb0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9",
-                "symfony/debug": "~2.8|~3.0",
-                "symfony/polyfill-mbstring": "~1.0"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/process": "~2.8|~3.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/process": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Console\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Console Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-09-28 00:11:12"
-        },
-        {
-            "name": "symfony/debug",
-            "version": "v3.1.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
-                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9",
-                "psr/log": "~1.0"
-            },
-            "conflict": {
-                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
-            },
-            "require-dev": {
-                "symfony/class-loader": "~2.8|~3.0",
-                "symfony/http-kernel": "~2.8|~3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Debug\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Debug Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
         },
         {
             "name": "symfony/event-dispatcher",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "029f82f655f81be8bf93782486596c02",
-    "content-hash": "62e9c8acbd74fd27017519b14a4a35f0",
+    "hash": "6f7ca58e4edd1a1b16098c827e27d7f9",
+    "content-hash": "f092f01a6eb0066f29e2684150f6e813",
     "packages": [
         {
             "name": "coduo/php-humanizer",
@@ -147,50 +147,105 @@
             "time": "2016-09-30 21:49:54"
         },
         {
-            "name": "mledoze/countries",
-            "version": "1.8.0",
+            "name": "phine/country",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/mledoze/countries.git",
-                "reference": "c212082894e48e8be123dad5dea7d9e6abc0c1b9"
+                "url": "https://github.com/kherge-abandoned/lib-country.git",
+                "reference": "17278e939832013a3c7981b71f63ceb7480e79a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/mledoze/countries/archive/master.zip",
-                "reference": "c212082894e48e8be123dad5dea7d9e6abc0c1b9",
-                "shasum": null
+                "url": "https://api.github.com/repos/kherge-abandoned/lib-country/zipball/17278e939832013a3c7981b71f63ceb7480e79a1",
+                "reference": "17278e939832013a3c7981b71f63ceb7480e79a1",
+                "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "symfony/console": "^2.7|^3.0",
-                "symfony/yaml": "^2.7|^3.0"
+                "phine/exception": "~1.0",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "league/phpunit-coverage-listener": "~1.0",
+                "phine/test": "~1.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
-                "psr-4": {
-                    "MLD\\": "src/MLD"
+                "psr-0": {
+                    "Phine\\Country": "src/lib"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Open Database License"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Mohammed Le Doze"
+                    "name": "Kevin Herrera",
+                    "email": "kevin@herrera.io",
+                    "homepage": "http://kevin.herrera.io"
                 }
             ],
-            "description": "World countries in JSON, CSV, XML and Yaml",
-            "homepage": "https://mledoze.github.io/countries/",
+            "description": "A PHP library for country and subdivision data.",
+            "homepage": "https://github.com/phine/lib-country",
             "keywords": [
                 "countries",
-                "csv",
-                "json",
-                "world",
-                "xml",
-                "yaml"
+                "country"
             ],
-            "time": "2016-09-01 09:41:00"
+            "time": "2015-04-21 03:50:08"
+        },
+        {
+            "name": "phine/exception",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kherge-abandoned/lib-exception.git",
+                "reference": "150c6b6090b2ebc53c60e87cb20c7f1287b7b68a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kherge-abandoned/lib-exception/zipball/150c6b6090b2ebc53c60e87cb20c7f1287b7b68a",
+                "reference": "150c6b6090b2ebc53c60e87cb20c7f1287b7b68a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "league/phpunit-coverage-listener": "~1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Phine\\Exception": "src/lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kevin Herrera",
+                    "email": "kevin@herrera.io",
+                    "homepage": "http://kevin.herrera.io"
+                }
+            ],
+            "description": "A PHP library for improving the use of exceptions.",
+            "homepage": "https://github.com/phine/lib-exception",
+            "keywords": [
+                "exception"
+            ],
+            "time": "2013-08-27 17:43:25"
         },
         {
             "name": "phpxmlrpc/phpxmlrpc",
@@ -244,55 +299,8 @@
             "time": "2016-10-01 12:29:37"
         },
         {
-            "name": "psr/log",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "time": "2016-10-10 12:19:37"
-        },
-        {
             "name": "symfony/config",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
@@ -344,135 +352,17 @@
             "time": "2016-09-25 08:27:07"
         },
         {
-            "name": "symfony/console",
-            "version": "v3.1.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "6cb0872fb57b38b3b09ff213c21ed693956b9eb0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6cb0872fb57b38b3b09ff213c21ed693956b9eb0",
-                "reference": "6cb0872fb57b38b3b09ff213c21ed693956b9eb0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9",
-                "symfony/debug": "~2.8|~3.0",
-                "symfony/polyfill-mbstring": "~1.0"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/process": "~2.8|~3.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/process": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Console\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Console Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-09-28 00:11:12"
-        },
-        {
-            "name": "symfony/debug",
-            "version": "v3.1.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
-                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.9",
-                "psr/log": "~1.0"
-            },
-            "conflict": {
-                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
-            },
-            "require-dev": {
-                "symfony/class-loader": "~2.8|~3.0",
-                "symfony/http-kernel": "~2.8|~3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Debug\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Debug Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
-        },
-        {
             "name": "symfony/filesystem",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "682fd8fdb3135fdf05fc496a01579ccf6c85c0e5"
+                "reference": "0565b61bf098cb4dc09f4f103f033138ae4f42c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/682fd8fdb3135fdf05fc496a01579ccf6c85c0e5",
-                "reference": "682fd8fdb3135fdf05fc496a01579ccf6c85c0e5",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/0565b61bf098cb4dc09f4f103f033138ae4f42c6",
+                "reference": "0565b61bf098cb4dc09f4f103f033138ae4f42c6",
                 "shasum": ""
             },
             "require": {
@@ -508,7 +398,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-14 00:18:46"
+            "time": "2016-10-18 04:30:12"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -571,16 +461,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "93013a18d272e59dab8e67f583155b78c68947eb"
+                "reference": "ff1285087397d2f64041b35e591f3025881c90cd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/93013a18d272e59dab8e67f583155b78c68947eb",
-                "reference": "93013a18d272e59dab8e67f583155b78c68947eb",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/ff1285087397d2f64041b35e591f3025881c90cd",
+                "reference": "ff1285087397d2f64041b35e591f3025881c90cd",
                 "shasum": ""
             },
             "require": {
@@ -631,20 +521,20 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
+            "time": "2016-10-18 04:30:12"
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "368b9738d4033c8b93454cb0dbd45d305135a6d3"
+                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/368b9738d4033c8b93454cb0dbd45d305135a6d3",
-                "reference": "368b9738d4033c8b93454cb0dbd45d305135a6d3",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/7ff51b06c6c3d5cc6686df69004a42c69df09e27",
+                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27",
                 "shasum": ""
             },
             "require": {
@@ -680,7 +570,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-25 08:27:07"
+            "time": "2016-10-24 18:41:13"
         },
         {
             "name": "xamin/handlebars.php",
@@ -1456,6 +1346,53 @@
             "time": "2015-10-02 06:51:40"
         },
         {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10 12:19:37"
+        },
+        {
             "name": "satooshi/php-coveralls",
             "version": "v1.0.1",
             "source": {
@@ -1964,17 +1901,135 @@
             "time": "2016-09-01 23:53:02"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v2.8.12",
+            "name": "symfony/console",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "889983a79a043dfda68f38c38b6dba092dd49cd8"
+                "url": "https://github.com/symfony/console.git",
+                "reference": "c99da1119ae61e15de0e4829196b9fba6f73d065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/889983a79a043dfda68f38c38b6dba092dd49cd8",
-                "reference": "889983a79a043dfda68f38c38b6dba092dd49cd8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c99da1119ae61e15de0e4829196b9fba6f73d065",
+                "reference": "c99da1119ae61e15de0e4829196b9fba6f73d065",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/debug": "~2.8|~3.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.8|~3.0",
+                "symfony/process": "~2.8|~3.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-10-06 01:44:51"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v3.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
+                "reference": "e2b3f74a67fc928adc3c1b9027f73e1bc01190a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+            },
+            "require-dev": {
+                "symfony/class-loader": "~2.8|~3.0",
+                "symfony/http-kernel": "~2.8|~3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-06 11:02:40"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v2.8.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "25c576abd4e0f212e678fe8b2bd9a9a98c7ea934"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/25c576abd4e0f212e678fe8b2bd9a9a98c7ea934",
+                "reference": "25c576abd4e0f212e678fe8b2bd9a9a98c7ea934",
                 "shasum": ""
             },
             "require": {
@@ -2021,11 +2076,11 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-28 16:56:28"
+            "time": "2016-10-13 01:43:15"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6f7ca58e4edd1a1b16098c827e27d7f9",
-    "content-hash": "f092f01a6eb0066f29e2684150f6e813",
+    "hash": "a05bb49c362db004fc33100906aff7e5",
+    "content-hash": "8662743fbdbcc105544a2cbc79002d46",
     "packages": [
         {
             "name": "coduo/php-humanizer",
@@ -70,14 +70,14 @@
         },
         {
             "name": "gios-asu/honeycomb",
-            "version": "1.0.0",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gios-asu/honeycomb.git",
-                "reference": "5e015dbe10a23004db9bbccc32e674b33d84d66f"
+                "reference": "b9ce04f86420b80706715d1c194c623269e49244"
             },
             "require": {
-                "gios-asu/nectary": "^0.1.2"
+                "gios-asu/nectary": ">=0.2.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "4.8.*",
@@ -99,15 +99,15 @@
                 }
             ],
             "description": "A framework for WordPress plugins",
-            "time": "2016-03-09 16:59:44"
+            "time": "2016-11-15 22:32:33"
         },
         {
             "name": "gios-asu/nectary",
-            "version": "0.1.9",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gios-asu/nectary.git",
-                "reference": "d7ad4baeb4e574e6780b19123b514c1700e44251"
+                "reference": "e46ab02826aaf8f10af4614305dafe0efb878122"
             },
             "require": {
                 "coduo/php-humanizer": ">=2.0.0-beta",
@@ -116,7 +116,8 @@
             "require-dev": {
                 "phpunit/phpunit": "4.8.*",
                 "satooshi/php-coveralls": ">=0.6",
-                "squizlabs/php_codesniffer": "2.*"
+                "squizlabs/php_codesniffer": "2.*",
+                "theseer/phpdox": "^0.8.1.1"
             },
             "type": "library",
             "autoload": {
@@ -144,7 +145,7 @@
                 }
             ],
             "description": "A simple PHP framework that is not tied to a web interface",
-            "time": "2016-09-30 21:49:54"
+            "time": "2016-11-15 20:46:34"
         },
         {
             "name": "phine/country",
@@ -402,16 +403,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
                 "shasum": ""
             },
             "require": {
@@ -423,7 +424,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -457,7 +458,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/translation",
@@ -1219,16 +1220,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.27",
+            "version": "4.8.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90"
+                "reference": "558a3a0d28b4cb7e4a593a4fbd2220e787076225"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c062dddcb68e44b563f66ee319ddae2b5a322a90",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/558a3a0d28b4cb7e4a593a4fbd2220e787076225",
+                "reference": "558a3a0d28b4cb7e4a593a4fbd2220e787076225",
                 "shasum": ""
             },
             "require": {
@@ -1287,7 +1288,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-21 06:48:14"
+            "time": "2016-11-14 06:25:28"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1736,16 +1737,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "reference": "938df7a6478e72795e5f8266cff24d06e3136f2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/938df7a6478e72795e5f8266cff24d06e3136f2e",
+                "reference": "938df7a6478e72795e5f8266cff24d06e3136f2e",
                 "shasum": ""
             },
             "require": {
@@ -1785,7 +1786,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2016-11-15 06:55:36"
         },
         {
             "name": "sebastian/version",

--- a/src/admin/asu-rfi-admin-page.php
+++ b/src/admin/asu-rfi-admin-page.php
@@ -37,17 +37,9 @@ class ASU_RFI_Admin_Page extends Hook {
         )
     );
 
-    $this->load_dependencies();
     $this->define_hooks();
-
   }
 
-  /**
-   * @override
-   */
-  public function load_dependencies() {
-    // No dependencies for now
-  }
 
   /**
    * Add filters and actions
@@ -97,12 +89,12 @@ class ASU_RFI_Admin_Page extends Hook {
     $path = plugin_dir_url( __FILE__ );
 
     add_options_page(
-            'Settings Admin', 
-            'ASU RFI Form', 
-            $capability, 
-            self::$page_name, 
-            array( $this, 'render_admin_page' )
-        );
+        'Settings Admin',
+        'ASU RFI Form',
+        $capability,
+        self::$page_name,
+        array( $this, 'render_admin_page' )
+    );
 
   }
 
@@ -163,9 +155,9 @@ HTML;
    * Handle form submissions for validations
    */
   public function form_submit( $input ) {
-    // intval the source_id_option_name 
-    if(isset($input[self::$source_id_option_name])) {
-      $input[self::$source_id_option_name] = intval($input[self::$source_id_option_name]);
+    // intval the source_id_option_name
+    if ( isset( $input[ self::$source_id_option_name ] ) ) {
+      $input[ self::$source_id_option_name ] = intval( $input[ self::$source_id_option_name ] );
     }
     return $input;
   }

--- a/src/admin/asu-rfi-admin-page.php
+++ b/src/admin/asu-rfi-admin-page.php
@@ -1,0 +1,173 @@
+<?php
+namespace ASURFIWordPress\Admin;
+use Honeycomb\Wordpress\Hook;
+// use ASURFIWordPress;
+
+// Avoid direct calls to this file
+if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
+  header( 'Status: 403 Forbidden' );
+  header( 'HTTP/1.1 403 Forbidden' );
+  exit();
+}
+
+/** ASU_RFI_Form_Shortcodes
+ * provides the shortcode [asu-rfi-form]
+ */
+class ASU_RFI_Admin_Page extends Hook {
+  use \ASURFIWordPress\Options_Handler_Trait;
+
+  public static $options_name = 'asu-rfi-options';
+  public static $options_group = 'asu-rfi-options_group';
+  public static $source_id_option_name = 'source_id';
+  public static $section_id = 'asu-rfi-section_id';
+  public static $section_name = 'asu-rfi-section_name';
+  public static $page_name = 'asu-rfi-admin-page';
+
+ public function __construct( $version = '0.1' ) {
+    parent::__construct( $version );
+
+    $this->add_action( 'admin_menu', $this, 'admin_menu' );
+    $this->add_action( 'admin_init', $this, 'admin_init' );
+
+    // Set default options
+    add_option(
+        self::$options_name,
+        array(
+          self::$source_id_option_name => 0,
+        )
+    );
+
+    $this->load_dependencies();
+    $this->define_hooks();
+
+  }
+
+  /**
+   * @override
+   */
+  public function load_dependencies() {
+    // No dependencies for now
+  }
+
+  /**
+   * Add filters and actions
+   *
+   * @override
+   */
+  public function define_hooks() {
+    $this->add_action( 'admin_init', $this, 'admin_init' );
+  }
+
+  /**
+   * Set up administrative fields
+   */
+  public function admin_init() {
+    register_setting(
+        self::$options_group,
+        self::$options_name,
+        array( $this, 'form_submit' )
+    );
+
+    add_settings_section(
+        self::$section_id,
+        'ASU RFI Settings',
+        array(
+          $this,
+          'print_section_info',
+        ),
+        self::$section_name
+    );
+
+    add_settings_field(
+        self::$source_id_option_name,
+        'Site Source Identifier',
+        array(
+          $this,
+          'source_id_on_callback',
+        ), // Callback
+        self::$section_name,
+        self::$section_id
+    );
+  }
+
+  public function admin_menu() {
+    $page_title = 'ASU RFI Plugin Settings';
+    $menu_title = 'ASU RFI';
+    $capability = 'manage_options';
+    $path = plugin_dir_url( __FILE__ );
+
+    add_options_page(
+            'Settings Admin', 
+            'ASU RFI Form', 
+            $capability, 
+            self::$page_name, 
+            array( $this, 'render_admin_page' )
+        );
+
+  }
+
+  public function render_admin_page() {
+    ?>
+    <div class="wrap">
+        <h1>ASU Request For Information Form Settings</h1>
+        <form method="post" action="options.php">
+        <?php
+            // This prints out all hidden setting fields
+            settings_fields( self::$options_group );
+            do_settings_sections( self::$section_name );
+            submit_button();
+        ?>
+        </form>
+    </div>
+    <?php
+  }
+
+
+  /**
+   * Print the section text
+   */
+  public function print_section_info() {
+    print 'Enter your settings below:';
+  }
+
+  /**
+   * Print the form section for the research group slugs
+   */
+  public function source_id_on_callback() {
+
+    $value = $this->get_option_attribute_or_default(
+        array(
+          'name'      => self::$options_name,
+          'attribute' => self::$source_id_option_name,
+          'default'   => '',
+        )
+    );
+
+    $html = <<<HTML
+    <input type="text" id="%s" name="%s[%s]" value="%s"/><br/>
+    <em>Source Identifiers are granted by the <a href="mailto:ecomm@asu.edu
+">ASU Enrollment Services Department</a>, please contact them to uptain a source_id for your college or department.</em>
+HTML;
+
+    printf(
+        $html,
+        self::$source_id_option_name,
+        self::$options_name,
+        self::$source_id_option_name,
+        $value
+    );
+
+  }
+
+  /**
+   * Handle form submissions for validations
+   */
+  public function form_submit( $input ) {
+    // intval the source_id_option_name 
+    if(isset($input[self::$source_id_option_name])) {
+      $input[self::$source_id_option_name] = intval($input[self::$source_id_option_name]);
+    }
+    return $input;
+  }
+
+}

--- a/src/registry/wordpress-registry.php
+++ b/src/registry/wordpress-registry.php
@@ -5,5 +5,6 @@
  */
 
 return [
-  ASURFIWordPress\Shortcodes\ASU_RFI_Form_Shortcodes::class
+  ASURFIWordPress\Shortcodes\ASU_RFI_Form_Shortcodes::class,
+  ASURFIWordPress\Admin\ASU_RFI_Admin_Page::class
 ];

--- a/src/registry/wordpress-registry.php
+++ b/src/registry/wordpress-registry.php
@@ -6,5 +6,5 @@
 
 return [
   ASURFIWordPress\Shortcodes\ASU_RFI_Form_Shortcodes::class,
-  ASURFIWordPress\Admin\ASU_RFI_Admin_Page::class
+  ASURFIWordPress\Admin\ASU_RFI_Admin_Page::class,
 ];

--- a/src/services/address-service.php
+++ b/src/services/address-service.php
@@ -2,26 +2,40 @@
 
 namespace ASURFIWordPress\Services;
 
+use Phine\Country\Loader\Loader;
+
+
 /** AddressService
  * Providing data on postal addresses to aide in Form building.
+ * Depends on the "mledoze/countries" package.
  */
 class AddressService {
 
   /**
-   *  Country names and Country codes in ISO_3166-1_alpha-2 format:
-   *   Array
+   * Country names and Country codes in ISO_3166-1_alpha-2 format indexed on country code:
+   *   [code] => Array
    *    (
    *        [name] => United States
    *        [code] => US
    *    )
    */
   public static function get_countries() {
-    $path_to_country_data = dirname( dirname( __DIR__ ) ) . '/vendor/mledoze/countries/dist/countries.json';
+    $loader = new Loader();
+    $countries = $loader->loadCountries();
 
-    $country_data = json_decode( file_get_contents( $path_to_country_data ) );
     return array_map( function( $item ) {
-        return array( 'name' => $item->name->common, 'code' => $item->cca2 );
-    }, $country_data);
+        return array( 'name' => $item->getShortName(), 'code' => $item->getAlpha2Code() );
+    }, $countries);
+  }
+
+
+  public static function get_states( $country_code ) {
+    $loader = new Loader();
+    $subdivisions = $loader->loadSubdivisions($country_code);
+
+    return array_map( function( $item ) {
+        return array( 'name' => $item->getName(), 'code' => $item->getCode() );
+    }, $subdivisions);
   }
 
 

--- a/src/services/address-service.php
+++ b/src/services/address-service.php
@@ -2,25 +2,27 @@
 
 namespace ASURFIWordPress\Services;
 
+/** AddressService
+ * Providing data on postal addresses to aide in Form building.
+ */
 class AddressService {
 
-
-
   /**
-   *  Country Codes and Country names in ISO_3166-1_alpha-2 format:
+   *  Country names and Country codes in ISO_3166-1_alpha-2 format:
    *   Array
    *    (
    *        [name] => United States
    *        [code] => US
    *    )
-   *   
    */
-  public static function getCountries() {
-    $path_to_country_data = dirname(dirname(__DIR__)).'/vendor/mledoze/countries/dist/countries.json';
+  public static function get_countries() {
+    $path_to_country_data = dirname( dirname( __DIR__ ) ) . '/vendor/mledoze/countries/dist/countries.json';
 
-    $country_data = json_decode( file_get_contents( $path_to_country_data ));
-    return array_map( function($item) {
-      return array('name' => $item->name->common, 'code' => $item->cca2);
+    $country_data = json_decode( file_get_contents( $path_to_country_data ) );
+    return array_map( function( $item ) {
+        return array( 'name' => $item->name->common, 'code' => $item->cca2 );
     }, $country_data);
   }
+
+
 }

--- a/src/services/address-service.php
+++ b/src/services/address-service.php
@@ -31,7 +31,7 @@ class AddressService {
 
   public static function get_states( $country_code ) {
     $loader = new Loader();
-    $subdivisions = $loader->loadSubdivisions($country_code);
+    $subdivisions = $loader->loadSubdivisions( $country_code );
 
     return array_map( function( $item ) {
         return array( 'name' => $item->getName(), 'code' => $item->getCode() );

--- a/src/services/address-service.php
+++ b/src/services/address-service.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ASURFIWordPress\Services;
+
+class AddressService {
+
+
+
+  /**
+   *  Country Codes and Country names in ISO_3166-1_alpha-2 format:
+   *   Array
+   *    (
+   *        [name] => United States
+   *        [code] => US
+   *    )
+   *   
+   */
+  public static function getCountries() {
+    $path_to_country_data = dirname(dirname(__DIR__)).'/vendor/mledoze/countries/dist/countries.json';
+
+    $country_data = json_decode( file_get_contents( $path_to_country_data ));
+    return array_map( function($item) {
+      return array('name' => $item->name->common, 'code' => $item->cca2);
+    }, $country_data);
+  }
+}

--- a/src/services/address-service.php
+++ b/src/services/address-service.php
@@ -4,6 +4,12 @@ namespace ASURFIWordPress\Services;
 
 use Phine\Country\Loader\Loader;
 
+// Avoid direct calls to this file
+if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
+  header( 'Status: 403 Forbidden' );
+  header( 'HTTP/1.1 403 Forbidden' );
+  exit();
+}
 
 /** AddressService
  * Providing data on postal addresses to aide in Form building.

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace ASURFIWordPress\Services;
+
+use PhpXmlRpc\Value;
+use PhpXmlRpc\Request;
+use PhpXmlRpc\Client;
+
+
+/** ASUDegreeService
+ * Providing data from ASU Degrees
+ */
+class ASUDegreeService {
+  const ASU_DIRECTORY_XML_RPC_SERVER = 'https://webapp4.asu.edu/programs/XmlRpcServer';
+
+  public function __construct( $client = null) {
+    if( null === $client ) {
+      $client = new Client(self::ASU_DIRECTORY_XML_RPC_SERVER);  
+    } 
+    $this->client = $client;
+  }
+
+  /* enrollment terms
+   * These are the peoplesoft term identifiers 
+   *  "2101" for Spring, 2010, or  3
+   *  "2104" for Summer, 2010, or  3
+   *  "2107" for Fall, 2010, or  2
+   *  "2109" for Winter, 2010 
+   *  "2177" for Summer, 2017
+   */
+  public function get_enrollment_terms() {
+    $semseter_names = array(
+      1 => 'Spring',
+      4 => 'Summer',
+      7 => 'Fall',
+      9 => 'Winter'
+    );
+
+    // TODO: this obviously should be more dynamic 
+    $years = array( '2017', '2018', '2019' );
+    $terms = array();
+
+    foreach($years as $year) {
+      foreach($semseter_names as $semseter_key => $semseter_name) {
+        $terms[]= array(
+          'code' => $this->encode_year_and_semester($year, $semseter_key), 
+          'name' => $semseter_name.' '.$year);
+      }
+    }
+    
+    return $terms;
+  }
+
+  /** encode_year_and_semester( $year, $semester_number ): 
+   * Given $year='2017', $semester_number = '4'
+   * returns '2174'
+   */
+  private function encode_year_and_semester( $year, $semester_number ) {
+    return substr($year,0,1).substr($year,2,2).$semester_number;
+  }
+
+}

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -39,7 +39,7 @@ class ASUDegreeService {
    *  "2109" for Winter, 2010
    *  "2177" for Summer, 2017
    */
-  public function get_available_enrollment_terms() {
+  public static function get_available_enrollment_terms() {
     $semseter_names = array(
       1 => 'Spring',
       4 => 'Summer',
@@ -54,8 +54,8 @@ class ASUDegreeService {
     foreach ( $years as $year ) {
       foreach ( $semseter_names as $semseter_key => $semseter_name ) {
         $terms[] = array(
-          'code' => $this->get_peoplesoft_semester_code( $year, $semseter_key ),
-          'name' => $semseter_name . ' ' . $year,
+          'value' => self::get_peoplesoft_semester_code( $year, $semseter_key ),
+          'label' => $semseter_name . ' ' . $year,
         );
       }
     }
@@ -68,7 +68,7 @@ class ASUDegreeService {
    * Given $year='2017', $semester_number = '4'
    * returns '2174'
    */
-  private function get_peoplesoft_semester_code( $year, $semester_number ) {
+  private static function get_peoplesoft_semester_code( $year, $semester_number ) {
     return substr( $year,0,1 ) . substr( $year,2,2 ) . $semester_number;
   }
 

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -10,25 +10,27 @@ use PhpXmlRpc\Client;
 /** ASUDegreeService
  * Providing data from ASU Degrees
  * XML RPC API Docs: http://www.public.asu.edu/~lcabre/javadocs/dsws/
+ *
  * @group services
  * @group asu-degree-service
  */
 class ASUDegreeService {
   const ASU_DIRECTORY_XML_RPC_SERVER = 'https://webapp4.asu.edu/programs/XmlRpcServer';
 
-  public function __construct( $client = null) {
-    if( null === $client ) {
-      $client = new Client(self::ASU_DIRECTORY_XML_RPC_SERVER);  
-    } 
+  public function __construct( $client = null ) {
+    if ( null === $client ) {
+      $client = new Client( self::ASU_DIRECTORY_XML_RPC_SERVER );
+    }
     $this->client = $client;
   }
 
-  /* enrollment terms
-   * These are the peoplesoft term identifiers 
+  /*
+   * enrollment terms
+   * These are the peoplesoft term identifiers
    *  "2101" for Spring, 2010, or  3
    *  "2104" for Summer, 2010, or  3
    *  "2107" for Fall, 2010, or  2
-   *  "2109" for Winter, 2010 
+   *  "2109" for Winter, 2010
    *  "2177" for Summer, 2017
    */
   public function get_available_enrollment_terms() {
@@ -36,40 +38,42 @@ class ASUDegreeService {
       1 => 'Spring',
       4 => 'Summer',
       7 => 'Fall',
-      9 => 'Winter'
+      9 => 'Winter',
     );
 
-    // TODO: this obviously should be more dynamic 
+    // TODO: this obviously should be more dynamic
     $years = array( '2017', '2018', '2019' );
     $terms = array();
 
-    foreach($years as $year) {
-      foreach($semseter_names as $semseter_key => $semseter_name) {
-        $terms[]= array(
-          'code' => $this->encode_year_and_semester($year, $semseter_key), 
-          'name' => $semseter_name.' '.$year);
+    foreach ( $years as $year ) {
+      foreach ( $semseter_names as $semseter_key => $semseter_name ) {
+        $terms[] = array(
+          'code' => $this->get_peoplesoft_semester_code( $year, $semseter_key ),
+          'name' => $semseter_name . ' ' . $year,
+        );
       }
     }
 
     return $terms;
   }
 
-  /** encode_year_and_semester( $year, $semester_number ): 
+  /*
+   * get_peoplesoft_semester_code( $year, $semester_number ):
    * Given $year='2017', $semester_number = '4'
    * returns '2174'
    */
-  private function encode_year_and_semester( $year, $semester_number ) {
-    return substr($year,0,1).substr($year,2,2).$semester_number;
+  private function get_peoplesoft_semester_code( $year, $semester_number ) {
+    return substr( $year,0,1 ) . substr( $year,2,2 ) . $semester_number;
   }
 
   // public function get_campuses() {
-  //   return array(
-  //     'TEMPE' => 'Tempe, Az',
-  //     'PLOY' => '',
-  //     'TDPHX' => 'Down Town Phoenix',
+  // return array(
+  // 'TEMPE' => 'Tempe, Az',
+  // 'PLOY' => '',
+  // 'TDPHX' => 'Down Town Phoenix',
 
-  //     String campus = "TEMPE" String campus = "POLY" String campus = "DTPHX" String campus = "WEST" String campus = "ONLNE"
-  //     );
+  // String campus = "TEMPE" String campus = "POLY" String campus = "DTPHX" String campus = "WEST" String campus = "ONLNE"
+  // );
   // }
 
   public function get_programs( $college ) {
@@ -77,8 +81,8 @@ class ASUDegreeService {
   }
 
   public function get_colleges() {
-    $request = new Request('eAdvisorDSFind.listColleges');
-    $response = $this->client->send($request);
+    $request = new Request( 'eAdvisorDSFind.listColleges' );
+    $response = $this->client->send( $request );
     return array_map( function( $item ) {
         return array( 'name' => $item->me['string'] );
     }, $response->val->me['array'] );

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -40,7 +40,7 @@ class ASUDegreeService {
    *  "2177" for Summer, 2017
    */
   public static function get_available_enrollment_terms() {
-    $semseter_names = array(
+    $semester_names = array(
       1 => 'Spring',
       4 => 'Summer',
       7 => 'Fall',
@@ -52,10 +52,10 @@ class ASUDegreeService {
     $terms = array();
 
     foreach ( $years as $year ) {
-      foreach ( $semseter_names as $semseter_key => $semseter_name ) {
+      foreach ( $semester_names as $semester_key => $semester_name ) {
         $terms[] = array(
-          'value' => self::get_peoplesoft_semester_code( $year, $semseter_key ),
-          'label' => $semseter_name . ' ' . $year,
+          'value' => self::get_peoplesoft_semester_code( $year, $semester_key ),
+          'label' => $semester_name . ' ' . $year,
         );
       }
     }

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -9,6 +9,9 @@ use PhpXmlRpc\Client;
 
 /** ASUDegreeService
  * Providing data from ASU Degrees
+ * XML RPC API Docs: http://www.public.asu.edu/~lcabre/javadocs/dsws/
+ * @group services
+ * @group asu-degree-service
  */
 class ASUDegreeService {
   const ASU_DIRECTORY_XML_RPC_SERVER = 'https://webapp4.asu.edu/programs/XmlRpcServer';
@@ -28,7 +31,7 @@ class ASUDegreeService {
    *  "2109" for Winter, 2010 
    *  "2177" for Summer, 2017
    */
-  public function get_enrollment_terms() {
+  public function get_available_enrollment_terms() {
     $semseter_names = array(
       1 => 'Spring',
       4 => 'Summer',
@@ -47,7 +50,7 @@ class ASUDegreeService {
           'name' => $semseter_name.' '.$year);
       }
     }
-    
+
     return $terms;
   }
 
@@ -57,6 +60,29 @@ class ASUDegreeService {
    */
   private function encode_year_and_semester( $year, $semester_number ) {
     return substr($year,0,1).substr($year,2,2).$semester_number;
+  }
+
+  // public function get_campuses() {
+  //   return array(
+  //     'TEMPE' => 'Tempe, Az',
+  //     'PLOY' => '',
+  //     'TDPHX' => 'Down Town Phoenix',
+
+  //     String campus = "TEMPE" String campus = "POLY" String campus = "DTPHX" String campus = "WEST" String campus = "ONLNE"
+  //     );
+  // }
+
+  public function get_programs( $college ) {
+
+  }
+
+  public function get_colleges() {
+    $request = new Request('eAdvisorDSFind.listColleges');
+    $response = $this->client->send($request);
+    return array_map( function( $item ) {
+        return array( 'name' => $item->me['string'] );
+    }, $response->val->me['array'] );
+
   }
 
 }

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -6,6 +6,12 @@ use PhpXmlRpc\Value;
 use PhpXmlRpc\Request;
 use PhpXmlRpc\Client;
 
+// Avoid direct calls to this file
+if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
+  header( 'Status: 403 Forbidden' );
+  header( 'HTTP/1.1 403 Forbidden' );
+  exit();
+}
 
 /** ASUDegreeService
  * Providing data from ASU Degrees

--- a/src/services/student-type-service.php
+++ b/src/services/student-type-service.php
@@ -2,6 +2,13 @@
 
 namespace ASURFIWordPress\Services;
 
+// Avoid direct calls to this file
+if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
+  header( 'Status: 403 Forbidden' );
+  header( 'HTTP/1.1 403 Forbidden' );
+  exit();
+}
+
 class StudentTypeService {
 
   public static function get_student_types() {

--- a/src/services/student-type-service.php
+++ b/src/services/student-type-service.php
@@ -8,17 +8,21 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
   header( 'HTTP/1.1 403 Forbidden' );
   exit();
 }
-
+/** StudentTypeService
+ *   Helper service to provide the different student types as defined by the
+ * routing data posting documentation from ASU Enrollment Services. Data is intended
+ * to populate drop down selections.
+ */
 class StudentTypeService {
 
   public static function get_student_types() {
     return array(
-        array('value' => 'Freshman', 'label' => 'Undergraduate Freshman'),
-        array('value' => 'Transfer', 'label' => 'Undergraduate Transfer'),
-        array('value' => 'Masters',  'label' => 'Graduate Masters'),
-        array('value' => 'Doctoral', 'label' => 'Graduate Doctoral'),
-        array('value' => 'cert',     'label' => 'Graduate Certificate'),
-        array('value' => 'nd', '      label' => 'Graduate Non-degree')
+        array( 'value' => 'Freshman', 'label' => 'Undergraduate Freshman' ),
+        array( 'value' => 'Transfer', 'label' => 'Undergraduate Transfer' ),
+        array( 'value' => 'Masters',  'label' => 'Graduate Masters' ),
+        array( 'value' => 'Doctoral', 'label' => 'Graduate Doctoral' ),
+        array( 'value' => 'cert',     'label' => 'Graduate Certificate' ),
+        array( 'value' => 'nd', '      label' => 'Graduate Non-degree' ),
       );
   }
 }

--- a/src/services/student-type-service.php
+++ b/src/services/student-type-service.php
@@ -22,7 +22,7 @@ class StudentTypeService {
         array( 'value' => 'Masters',  'label' => 'Graduate Masters' ),
         array( 'value' => 'Doctoral', 'label' => 'Graduate Doctoral' ),
         array( 'value' => 'cert',     'label' => 'Graduate Certificate' ),
-        array( 'value' => 'nd', '      label' => 'Graduate Non-degree' ),
+        array( 'value' => 'nd',       'label' => 'Graduate Non-degree' ),
       );
   }
 }

--- a/src/services/student-type-service.php
+++ b/src/services/student-type-service.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ASURFIWordPress\Services;
+
+class StudentTypeService {
+
+  public static function get_student_types() {
+    return array(
+        array('value' => 'Freshman', 'label' => 'Undergraduate Freshman'),
+        array('value' => 'Transfer', 'label' => 'Undergraduate Transfer'),
+        array('value' => 'Masters',  'label' => 'Graduate Masters'),
+        array('value' => 'Doctoral', 'label' => 'Graduate Doctoral'),
+        array('value' => 'cert',     'label' => 'Graduate Certificate'),
+        array('value' => 'nd', '      label' => 'Graduate Non-degree')
+      );
+  }
+}

--- a/src/services/student-type-service.php
+++ b/src/services/student-type-service.php
@@ -17,12 +17,12 @@ class StudentTypeService {
 
   public static function get_student_types() {
     return array(
-        array( 'value' => 'Freshman', 'label' => 'Undergraduate Freshman' ),
-        array( 'value' => 'Transfer', 'label' => 'Undergraduate Transfer' ),
-        array( 'value' => 'Masters',  'label' => 'Graduate Masters' ),
-        array( 'value' => 'Doctoral', 'label' => 'Graduate Doctoral' ),
-        array( 'value' => 'cert',     'label' => 'Graduate Certificate' ),
-        array( 'value' => 'nd',       'label' => 'Graduate Non-degree' ),
+        array( 'value' => 'Freshman', 'label' => 'Undergraduate Freshman Student' ),
+        array( 'value' => 'Transfer', 'label' => 'Undergraduate Transfer Student' ),
+        array( 'value' => 'Masters',  'label' => 'Graduate Masters Student' ),
+        array( 'value' => 'Doctoral', 'label' => 'Graduate Doctoral Student' ),
+        array( 'value' => 'cert',     'label' => 'Graduate Certificate Student' ),
+        array( 'value' => 'nd',       'label' => 'Graduate Non-Degree Seeking Student' ),
       );
   }
 }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -32,47 +32,47 @@ class ASU_RFI_Form_Shortcodes extends Hook {
     $this->add_action( 'wp_enqueue_scripts', $this, 'wp_enqueue_scripts' );
     $this->add_shortcode( 'asu-rfi-form', $this, 'asu_rfi_form' );
     $this->add_action( 'init', $this, 'setup_rewrites' );
-    $this->add_action( 'wp', $this, 'add_http_cache_header' ); 
+    $this->add_action( 'wp', $this, 'add_http_cache_header' );
     $this->add_action( 'wp_head', $this, 'add_html_cache_header' );
   }
 
-  /** 
+  /**
    * Shorthand view wrapper to make rendering a view using nectary's factories easier in this plugin
    */
   private function view( $template_name ) {
     return new \Nectary\Factories\View_Factory( $template_name, $this->path_to_views );
   }
 
-  /** 
-   * Do not cache any sensitive form data - ASU Web Application Security Standards 
+  /**
+   * Do not cache any sensitive form data - ASU Web Application Security Standards
    */
   public function add_html_cache_header() {
-    if( $this->current_page_has_rfi_shortcode() ) {
+    if ( $this->current_page_has_rfi_shortcode() ) {
       echo '<meta http-equiv="Pragma" content="no-cache"/>
             <meta http-equiv="Expires" content="-1"/>
             <meta http-equiv="Cache-Control" content="no-store,no-cache" />';
     }
   }
 
-  /** 
-   * Do not cache any sensitive form data - ASU Web Application Security Standards 
+  /**
+   * Do not cache any sensitive form data - ASU Web Application Security Standards
    * This call back needs to hook after send_headers since we depend on the $post variable
    * and that is not populated at the time of send_headers.
    */
   public function add_http_cache_header() {
-    if( $this->current_page_has_rfi_shortcode() ) {
-      header('Cache-Control: no-Cache, no-Store, must-Revalidate');
-      header('Pragma: no-Cache');
-      header('Expires: 0');
+    if ( $this->current_page_has_rfi_shortcode() ) {
+      header( 'Cache-Control: no-Cache, no-Store, must-Revalidate' );
+      header( 'Pragma: no-Cache' );
+      header( 'Expires: 0' );
     }
   }
 
-  /** 
-   * return true if the page is using the [asu-rfi-form] shortcode, else false
+  /**
+   * Returns true if the page is using the [asu-rfi-form] shortcode, else false
    */
   private function current_page_has_rfi_shortcode() {
     global $post;
-    return ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'asu-rfi-form') );
+    return ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'asu-rfi-form' ) );
   }
 
   /** Set up any url rewrites:
@@ -89,7 +89,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    * Hooks onto `wp_enqueue_scritps`.
    */
   public function wp_enqueue_scripts() {
-    if( $this->current_page_has_rfi_shortcode() ) {
+    if ( $this->current_page_has_rfi_shortcode() ) {
       $url_to_css_file = plugin_dir_url( dirname( dirname( __FILE__ ) ) ) . 'assets/css/asu-rfi.css';
       wp_enqueue_style( $this->plugin_slug, $url_to_css_file, array(), $this->version );
     }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -49,10 +49,11 @@ class ASU_RFI_Form_Shortcodes extends Hook {
     wp_enqueue_style( $this->plugin_slug, $url_to_css_file, array(), $this->version );
   }
 
+  /**
+   * Handle the shortcode [asu-rfi-form]
+   */
   public function asu_rfi_form( $atts, $content = '' ) {
-
-    $response = view('rfi-form.form')->add_data(
-        array(
+    $view_data =  array(
           'redirect_back_url' => get_permalink(),
           'source_id' => 87,
           'testmode' => 'Test',
@@ -65,8 +66,21 @@ class ASU_RFI_Form_Shortcodes extends Hook {
           //   'field_label' => 'First',
           //   'field_type' => 'text'),
           'student_types' => Services\StudentTypeService::get_student_types()
-        )
-      )->build();
+        );
+
+    $response_status_code = get_query_var('statusFlag');
+    if( $response_status_code ) {
+      $message = get_query_var('msg');
+      // we have submitted the request form and should display a success or error message 
+      if( '200' == $response_status_code ) {
+        $view_data['success_message'] = $message ? $message : 'Thank you for submitting';
+      } else  {
+        $view_data['error_message'] = $message ? $message : 'Something went wrong with your submission';
+        error_log('error submitting ASU RFI (code: '.$response_status_code.') :'.$message);
+      }
+    }
+
+    $response = view('rfi-form.form')->add_data($view_data )->build();
     return $response->content;
   }
 

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -62,8 +62,8 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    * Handle the shortcode [asu-rfi-form]
    *   attributes:
    *     type = 'full' or leave blank for the default simple form
-   *     degreeLevel = 'ugrad' or 'grad' Default is 'ugrad'
-   *     testmode = 'test' or leave blank for the default production
+   *     degree_level = 'ugrad' or 'grad' Default is 'ugrad'
+   *     test_mode = 'test' or leave blank for the default production
    *     source_id = integer site identifier (issued by Enrollment services department) will default to site wide setting 
    */
   public function asu_rfi_form( $atts, $content = '' ) {
@@ -78,11 +78,11 @@ class ASU_RFI_Form_Shortcodes extends Hook {
               )
           ),
           'testmode' => 'Prod', // default to production mode
-          'degreeLevel' => 'ugrad', // or 'grad'
+          'degreeLevel' => 'ugrad', // default to und
           'student_types' => Services\StudentTypeService::get_student_types()
         );
 
-    if( isset( $atts['testmode'] ) && 'test' == $atts['testmode'] ) {
+    if( isset( $atts['test_mode'] ) && 0 === strcasecmp('test', $atts['test_mode'] ) ) {
       $view_data['testmode'] = 'Test';
     }
 
@@ -91,6 +91,13 @@ class ASU_RFI_Form_Shortcodes extends Hook {
       $view_data['source_id'] = intval($atts['source_id']);
     }
 
+    // Use the attribute source id over the sites option 
+    if( isset( $atts['degree_level'] ) && (
+         0 === strcasecmp('grad', $atts['degree_level'] ) || 
+         0 === strcasecmp('graduate', $atts['degree_level'] ) ) ) {
+      $view_data['degreeLevel'] = 'grad';
+      error_log("graduate level engage!");
+    }
 
     $view_data = $this->look_for_a_submission_response( $view_data );
 

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -23,7 +23,9 @@ class ASU_RFI_Form_Shortcodes extends Hook {
   public function asu_rfi_form( $atts, $content = '' ) {
      $response = view('rfi-form.form')->add_data(
         array(
-          'redirect_back_url' => get_permalink()
+          'redirect_back_url' => get_permalink(),
+          'source_id' => 87,
+          'testmode' => 'Test',
         )
     )->build();
     return $response->content;

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -64,13 +64,13 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    *     type = 'full' or leave blank for the default simple form
    *     degree_level = 'ugrad' or 'grad' Default is 'ugrad'
    *     test_mode = 'test' or leave blank for the default production
-   *     source_id = integer site identifier (issued by Enrollment services department) will default to site wide setting 
+   *     source_id = integer site identifier (issued by Enrollment services department) will default to site wide setting
    */
   public function asu_rfi_form( $atts, $content = '' ) {
-    $view_data =  array(
+    $view_data = array(
           'form_endpoint' => self::DEVELOPMENT_FORM_ENDPOINT,
           'redirect_back_url' => get_permalink(),
-          'source_id' =>  $value = $this->get_option_attribute_or_default(
+          'source_id' => $value = $this->get_option_attribute_or_default(
               array(
                 'name'      => Admin\ASU_RFI_Admin_Page::$options_name,
                 'attribute' => Admin\ASU_RFI_Admin_Page::$source_id_option_name,
@@ -79,31 +79,31 @@ class ASU_RFI_Form_Shortcodes extends Hook {
           ),
           'testmode' => 'Prod', // default to production mode
           'degreeLevel' => 'ugrad', // default to und
-          'student_types' => Services\StudentTypeService::get_student_types()
+          'student_types' => Services\StudentTypeService::get_student_types(),
         );
 
-    if( isset( $atts['test_mode'] ) && 0 === strcasecmp('test', $atts['test_mode'] ) ) {
+    if ( isset( $atts['test_mode'] ) && 0 === strcasecmp( 'test', $atts['test_mode'] ) ) {
       $view_data['testmode'] = 'Test';
     }
 
-    // Use the attribute source id over the sites option 
-    if( isset( $atts['source_id'] ) ) {
-      $view_data['source_id'] = intval($atts['source_id']);
+    // Use the attribute source id over the sites option
+    if ( isset( $atts['source_id'] ) ) {
+      $view_data['source_id'] = intval( $atts['source_id'] );
     }
 
-    // Use the attribute source id over the sites option 
-    if( isset( $atts['degree_level'] ) && (
-         0 === strcasecmp('grad', $atts['degree_level'] ) || 
-         0 === strcasecmp('graduate', $atts['degree_level'] ) ) ) {
+    // Use the attribute source id over the sites option
+    if ( isset( $atts['degree_level'] ) && (
+         0 === strcasecmp( 'grad', $atts['degree_level'] ) ||
+         0 === strcasecmp( 'graduate', $atts['degree_level'] ) ) ) {
       $view_data['degreeLevel'] = 'grad';
-      error_log("graduate level engage!");
+      error_log( 'graduate level engage!' );
     }
 
     $view_data = $this->look_for_a_submission_response( $view_data );
 
     // Figure out which form to show
     $view_name = 'rfi-form.simple-request-info-form';
-    if(isset($atts['type']) && $atts['type'] == 'full') {
+    if ( isset( $atts['type'] ) && 0 === strcasecmp( 'full', $atts['type'] ) ) {
       $view_name = 'rfi-form.form';
     }
 
@@ -111,18 +111,18 @@ class ASU_RFI_Form_Shortcodes extends Hook {
     return $response->content;
   }
 
-  /** look_for_a_submission_response() 
-   * Look at the statusFlag and msg query var and return a human readable message that can be used 
+  /**
+   * Look at the statusFlag and msg query var and return a human readable message that can be used
    */
   private function look_for_a_submission_response( $view_data ) {
-    $response_status_code = get_query_var('statusFlag');
-    if( $response_status_code ) {
-      $message = get_query_var('msg');
-      // we have submitted the request form and should display a success or error message 
-      if( '200' == $response_status_code ) {
+    $response_status_code = get_query_var( 'statusFlag' );
+    if ( $response_status_code ) {
+      $message = get_query_var( 'msg' );
+      // we have submitted the request form and should display a success or error message
+      if ( 200 === intval( $response_status_code ) ) {
         $view_data['success_message'] = $message ? $message : 'Thank you for submitting';
-      } else  {
-        error_log('error submitting ASU RFI (code: '.$response_status_code.') : '.$message);
+      } else {
+        error_log( 'error submitting ASU RFI (code: ' . $response_status_code . ') : ' . $message );
         $view_data['error_message'] = $message ? $message : 'Something went wrong with your submission';
       }
     }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -6,9 +6,14 @@ use Honeycomb\Wordpress\Hook;
  * provides the shortcode [asu-rfi-form]
  */
 class ASU_RFI_Form_Shortcodes extends Hook {
+  private $path_to_views;
 
   public function __construct() {
     $this->define_hooks();
+    $this->path_to_views = __DIR__ . '/../views/';
+
+    $instance = \Nectary\Configuration::get_instance();
+    $instance->add( 'path_to_views', __DIR__ . '/../views/' );
   }
 
   public function define_hooks() {
@@ -16,7 +21,12 @@ class ASU_RFI_Form_Shortcodes extends Hook {
   }
 
   public function asu_rfi_form( $atts, $content = '' ) {
-    return 'Hello from the ASU RFI Form';
+     $response = view('rfi-form.form')->add_data(
+        array(
+          'redirect_back_url' => get_permalink()
+        )
+    )->build();
+    return $response->content;
   }
 
 }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -18,6 +18,8 @@ class ASU_RFI_Form_Shortcodes extends Hook {
 
   public function define_hooks() {
     $this->add_shortcode( 'asu-rfi-form', $this, 'asu_rfi_form' );
+    // TODO: add url variables 'statusFlag' and 'msg' eg: ?statusFlag=200&msg=Sucessful%20submission
+
   }
 
   public function asu_rfi_form( $atts, $content = '' ) {
@@ -26,6 +28,22 @@ class ASU_RFI_Form_Shortcodes extends Hook {
           'redirect_back_url' => get_permalink(),
           'source_id' => 87,
           'testmode' => 'Test',
+          'first_name' => 'foo',
+          'degreeLevel' => 'ugrad', // or 'grad'
+          // 'first' => array(
+          //   'required' => true,
+          //   'placeholder' => 'First Name',
+          //   'field_name' => 'firstName',
+          //   'field_label' => 'First',
+          //   'field_type' => 'text'),
+          'student_types' => array(
+            array('value' => 'Freshman', 'label' => 'Undergraduate Freshman'),
+            array('value' => 'Transfer', 'label' => 'Undergraduate Transfer'),
+            array('value' => 'Masters', 'label' => 'Graduate Masters'),
+            array('value' => 'Doctoral', 'label' => 'Graduate Doctoral'),
+            array('value' => 'cert', 'label' => 'Graduate Certificate'),
+            array('value' => 'nd', 'label' => 'Graduate Non-degree')
+          )
         )
     )->build();
     return $response->content;

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -85,13 +85,15 @@ class ASU_RFI_Form_Shortcodes extends Hook {
   }
 
   /**
-   * Enqueue the CSS
-   * Hooks onto `wp_enqueue_scritps`.
+   * Enqueue CSS and JS
+   * Hooks onto `wp_enqueue_scripts`.
    */
   public function wp_enqueue_scripts() {
     if ( $this->current_page_has_rfi_shortcode() ) {
       $url_to_css_file = plugin_dir_url( dirname( dirname( __FILE__ ) ) ) . 'assets/css/asu-rfi.css';
       wp_enqueue_style( $this->plugin_slug, $url_to_css_file, array(), $this->version );
+      $url_to_jquery_validator = plugin_dir_url( dirname( dirname( __FILE__ ) ) ) . 'bower_components/jquery-validation/dist/jquery.validate.min.js';
+      wp_enqueue_script( 'jquery-validation', $url_to_jquery_validator, array( 'jquery' ), '1.16.0', false );
     }
   }
 

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -54,6 +54,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    */
   public function asu_rfi_form( $atts, $content = '' ) {
     $view_data =  array(
+          'form_endpoint' => 'https://requestinfo-qa.asu.edu/routing_form_post', // could aslo be requestinfo.asu.edu for prod
           'redirect_back_url' => get_permalink(),
           'source_id' => 87,
           'testmode' => 'Test',

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -121,10 +121,10 @@ class ASU_RFI_Form_Shortcodes extends Hook {
       $message = get_query_var( 'msg' );
       // we have submitted the request form and should display a success or error message
       if ( 200 === intval( $response_status_code ) ) {
-        $view_data['success_message'] = $message ? $message : 'Thank you for submitting';
+        $view_data['success_message'] = 'Thank you for your submission!';
       } else {
         error_log( 'error submitting ASU RFI (code: ' . $response_status_code . ') : ' . $message );
-        $view_data['error_message'] = $message ? $message : 'Something went wrong with your submission';
+        $view_data['error_message'] = $message ? 'Error:'.$message : 'Something went wrong with your submission';
       }
     }
     return $view_data;

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -8,18 +8,29 @@ use Honeycomb\Wordpress\Hook;
 class ASU_RFI_Form_Shortcodes extends Hook {
   private $path_to_views;
 
-  public function __construct() {
-    $this->define_hooks();
+  public function __construct( $version ) {
+    parent::__construct( 'asu-rfi-form-shortcodes', $version );
     $this->path_to_views = __DIR__ . '/../views/';
+    $this->define_hooks();
 
     $instance = \Nectary\Configuration::get_instance();
     $instance->add( 'path_to_views', __DIR__ . '/../views/' );
   }
 
   public function define_hooks() {
+    $this->add_action( 'wp_enqueue_scripts', $this, 'wp_enqueue_scripts' );
     $this->add_shortcode( 'asu-rfi-form', $this, 'asu_rfi_form' );
     // TODO: add url variables 'statusFlag' and 'msg' eg: ?statusFlag=200&msg=Sucessful%20submission
 
+  }
+
+  /**
+   * Enqueue the CSS
+   * Hooks onto `wp_enqueue_scritps`.
+   */
+  public function wp_enqueue_scripts() {
+    $url_to_css_file = plugin_dir_url( dirname( dirname( __FILE__ ) ) ) . 'assets/css/asu-rfi.css';
+    wp_enqueue_style( $this->plugin_slug, $url_to_css_file, array(), $this->version );
   }
 
   public function asu_rfi_form( $atts, $content = '' ) {

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -124,7 +124,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
         $view_data['success_message'] = 'Thank you for your submission!';
       } else {
         error_log( 'error submitting ASU RFI (code: ' . $response_status_code . ') : ' . $message );
-        $view_data['error_message'] = $message ? 'Error:'.$message : 'Something went wrong with your submission';
+        $view_data['error_message'] = $message ? 'Error:' . $message : 'Something went wrong with your submission';
       }
     }
     return $view_data;

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -79,6 +79,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
           ),
           'testmode' => 'Prod', // default to production mode
           'degreeLevel' => 'ugrad', // default to und
+          'enrollment_terms' => Services\ASUDegreeService::get_available_enrollment_terms(),
           'student_types' => Services\StudentTypeService::get_student_types(),
         );
 

--- a/src/traits/options-handler-trait.php
+++ b/src/traits/options-handler-trait.php
@@ -4,9 +4,9 @@ namespace ASURFIWordPress;
 
 trait Options_Handler_Trait {
   /**
-    * Get Option Attribute or a default value - just a wrapper on get_option.
-    *  NOTE: it does escape html, so if your expecting back you need to decode it.
-    */
+   * Get Option Attribute or a default value - just a wrapper on get_option.
+   *  NOTE: it does escape html, so if your expecting back you need to decode it.
+   */
   public function get_option_attribute_or_default( $options ) {
     $options_name      = array_key_exists( 'name', $options ) ? $options['name'] : '';
     $options_parameter = array_key_exists( 'attribute', $options ) ? $options['attribute'] : '';

--- a/src/traits/options-handler-trait.php
+++ b/src/traits/options-handler-trait.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ASURFIWordPress;
+
+trait Options_Handler_Trait {
+  /**
+    * Get Option Attribute or a default value - just a wrapper on get_option.
+    *  NOTE: it does escape html, so if your expecting back you need to decode it.
+    */
+  public function get_option_attribute_or_default( $options ) {
+    $options_name      = array_key_exists( 'name', $options ) ? $options['name'] : '';
+    $options_parameter = array_key_exists( 'attribute', $options ) ? $options['attribute'] : '';
+    $default           = array_key_exists( 'default', $options ) ? $options['default'] : '';
+
+    $options = get_option( $options_name );
+
+    if ( isset( $options[ $options_parameter ] ) ) {
+      $default = esc_attr( $options[ $options_parameter ] );
+    }
+
+    return $default;
+  }
+}

--- a/src/views/rfi-form/form-javascript.handlebars
+++ b/src/views/rfi-form/form-javascript.handlebars
@@ -1,0 +1,5 @@
+<script>
+  (function($) {
+    $('#registrationForm').validate();
+  })(jQuery)
+</script>

--- a/src/views/rfi-form/form.handlebars
+++ b/src/views/rfi-form/form.handlebars
@@ -1,30 +1,144 @@
-<form method="post" action="https://requestinfo-qa.asu.edu/routing_form_post">
-  <ul>
-      <li>First: <input type="text" name="firstName" value="{{ first_name }}">*</li>
-      <li>Last: <input type="text" name="lastName">*</li>
-      <li>Birthdate: <input type="text" name="birthdate"></li>
-      <li>Email: <input type="text" name="emailAddress">*</li>
-      <li>countryOfCitizenship: <input type="text" name="countryOfCitizenship"> </li>
-      <li>veteranStatus: <input type="text" name="veteranStatus"></li>
-      <li>countryOfResidence: <input type="text" name="countryOfResidence"> </li>
-      <li>addressLine1: <input type="text" name="addressLine1"></li>
-      <li>city: <input type="text" name="city"></li>
-      <li>state: <input type="text" name="state"></li>
-      <li>zip: <input type="text" name="zip" ></li>
-      <li>phoneNumber: <input type="text" name="phoneNumber"> </li>
-      <li>currentPrevStudent: <input type="text" name="currentPrevStudent"> </li>
-      <li>projectedEnrollment: <input type="text" name="projectedEnrollment">*</li>
-      <li>collegeOfInterest: <input type="text" name="collegeOfInterest">*</li>
-      <li>poiCode: <input type="text" name="poiCode">*</li>
-      <li>online: <input type="text" name="online"></li>
-      <li>trackingId: <input type="text" name="trackingId"></li>
-      <li>questions: <input type="text" name="questions"></li>
-      <li>degreeLevel: <input type="text" name="degreeLevel" value="ugrad"></li>
+<form method="post" action="https://requestinfo-qa.asu.edu/routing_form_post" class="form-horizontal">
 
-      <input type="hidden" name="testmode" value="{{ testmode }}">
-      <input type="hidden" name="formUrl" value="{{ redirect_back_url }}">
-      <input type="hidden" name="source_id" value="{{ source_id }}">
+    <input type="hidden" name="degreeLevel" value="{{ degreeLevel }}">
+    <input type="hidden" name="testmode" value="{{ testmode }}">
+    <input type="hidden" name="formUrl" value="{{ redirect_back_url }}">
+    <input type="hidden" name="source_id" value="{{ source_id }}">
+    <div class='honey'><input type="text" name="email"></div>
 
-      <li><input type="submit" value="Submit"></li>
-  </ul>
+      <div class="form-group required has-feedback">
+        <label class="control-label col-sm-3" for="firstName">First Name</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="firstName" name="firstName" value="{{ first_name }}" placeholder="First Name" maxlength="40">
+        </div>
+      </div>
+      <div class="form-group required has-feedback">
+        <label class="control-label col-sm-3" for="lastName">Last Name</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="lastName" name="lastName" value="{{ last_name }}" placeholder="Last Name" maxlength="50">
+        </div>
+      </div>
+      <div class="form-group required has-feedback">
+        <label class="control-label col-sm-3" for="emailAddress">Email</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="emailAddress" name="emailAddress" value="{{ email }}" placeholder="Email@example.com" maxlength="50">
+        </div>
+      </div>
+      <div class="form-group has-feedback">
+        <label class="control-label col-sm-3" for="birthdate">Birthdate</label>
+        <div class="col-sm-9">
+          <input type="date" class="form-control" id="birthdate" name="birthdate" value="{{ email }}" placeholder="YYYY-MM-DD"> {{!-- TODO: polyfil date picker --}}
+        </div>
+      </div>
+      <div class="form-group has-feedback">
+        <label class="control-label col-sm-3" for="countryOfCitizenship">Country Of Citizenship</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="countryOfCitizenship" name="countryOfCitizenship" value="{{ countryOfCitizenship }}">
+        </div>
+      </div>
+      <div class="form-group has-feedback">
+        <label class="control-label col-sm-3" for="veteranStatus">US Military/Veteran Status</label>
+        <div class="col-sm-9">
+          <select name="veteranStatus" id="veteranStatus" class="form-select">
+            <option value="" selected="selected">- None -</option>
+            <option value="member">I am a service member or a veteran</option>
+            <option value="dependent">I am a spouse or dependent of a service member or a veteran</option>
+          </select>
+        </div>
+      </div>
+      <div class="form-group has-feedback">
+        <label class="control-label col-sm-3" for="countryOfResidence">Country Of Residence</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="countryOfResidence" name="countryOfResidence" value="{{ countryOfResidence }}">
+        </div>
+      </div>
+      <div class="form-group has-feedback">
+        <label class="control-label col-sm-3" for="addressLine1">Address</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="addressLine1" name="addressLine1" value="{{ addressLine1 }}" maxlength="50">
+        </div>
+      </div>
+      <div class="form-group has-feedback">
+        <label class="control-label col-sm-3" for="city">City</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="city" name="city" value="{{ city }}" maxlength="40">
+        </div>
+      </div>
+      <div class="form-group has-feedback">
+        <label class="control-label col-sm-3" for="state">State</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="state" name="state" value="{{ state }}" maxlength="40">
+        </div>
+      </div>
+      <div class="form-group has-feedback">
+        <label class="control-label col-sm-3" for="zip">Zip Code</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="zip" name="zip" value="{{ zip }}" maxlength="20">
+        </div>
+      </div>
+      <div class="form-group has-feedback">
+        <label class="control-label col-sm-3" for="phoneNumber">Phone</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="phoneNumber" name="phoneNumber" value="{{ phoneNumber }}" placeholder='(123) 456-7890' maxlength="30">
+        </div>
+      </div>
+{{!-- Not a documented feild???      --}}
+      <!-- <div class="form-group has-feedback">
+        <label class="control-label col-sm-3" for="currentPrevStudent">Current or Previous Student?</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="currentPrevStudent" name="currentPrevStudent" value="{{ currentPrevStudent }}">
+        </div>
+      </div> -->
+      <div class="form-group has-feedback required">
+        <label class="control-label col-sm-3" for="projectedEnrollment">Projected Enrollment Term</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="projectedEnrollment" name="projectedEnrollment" value="{{ projectedEnrollment }}" placeholder=''> {{!-- TODO: needs to be a dropdown of peoplesoft codes --}}
+        </div>
+      </div>
+      <div class="form-group has-feedback required">
+        <label class="control-label col-sm-3" for="collegeOfInterest">Program code</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="collegeOfInterest" name="collegeOfInterest" value="{{ collegeOfInterest }}" placeholder='' maxlength="4"> {{!-- TODO: needs to be a dropdown of Degree codes (e.g. UGBA or GRHI ) --}}
+        </div>
+      </div>
+      <div class="form-group has-feedback required">
+        <label class="control-label col-sm-3" for="poiCode">Plan code</label>
+        <div class="col-sm-9">
+          <input type="text" class="form-control" id="poiCode" name="poiCode" value="{{ poiCode }}" placeholder='' maxlength="10"> {{!-- TODO: needs to be a dropdown of valid plan codes, please check Degree Search for valid codes (e.g. BAFULLMBA) --}}
+        </div>
+      </div>
+      <div class="form-group has-feedback">
+        <label class="control-label col-sm-3" for="StudentType">Student Type</label>
+        <div class="col-sm-9">
+          <select name="StudentType" id="StudentType" class="form-select">
+            <option value="" selected="selected">-</option>
+            {{#each student_types }}
+              <option value="{{ value }}">{{ label }}</option>
+            {{/each}}
+          </select>
+        </div>
+      </div>
+      <div class="form-group has-feedback">
+        <label class="control-label col-sm-3" for="online">Interested in taking Online courses?</label>
+        <div class="col-sm-9">
+          <select name="online" id="online" class="form-select">
+            <option value="" selected="selected">-</option>
+            <option value="Yes">Yes</option>
+            <option value="No">No</option>
+          </select>
+        </div>
+      </div>
+      <div class="form-group has-feedback required">
+        <label class="control-label col-sm-3" for="question">Additional Questions?</label>
+        <div class="col-sm-9">
+          <textarea type="text" class="form-control" id="question" name="question" maxlength="500"></textarea>
+        </div>
+      </div>
+      <div class="form-group has-feedback required">
+        <label class="control-label col-sm-3" for="submit"></label>
+        <div class="col-sm-9">
+          <input type="submit" value="Submit" class="btn btn-default">
+        </div>
+      </div>
+
 </form>

--- a/src/views/rfi-form/form.handlebars
+++ b/src/views/rfi-form/form.handlebars
@@ -11,7 +11,7 @@
   </div>
 {{/if}}
 
-<form method="post" action="https://requestinfo-qa.asu.edu/routing_form_post" class="form-horizontal">
+<form method="post" action="{{ form_endpoint }}" class="form-horizontal">
 
     <input type="hidden" name="degreeLevel" value="{{ degreeLevel }}">
     <input type="hidden" name="testmode" value="{{ testmode }}">

--- a/src/views/rfi-form/form.handlebars
+++ b/src/views/rfi-form/form.handlebars
@@ -1,0 +1,31 @@
+<form method="post" action="https://requestinfo-qa.asu.edu/routing_form_post">
+<ul>
+      <li>First: <input type="text" name="firstName" value="foo">*</li>
+      <li>Last: <input type="text" name="lastName">*</li>
+      <li>Birthdate: <input type="text" name="birthdate"></li>
+      <li>Email: <input type="text" name="emailAddress">*</li>
+      <li>countryOfCitizenship: <input type="text" name="countryOfCitizenship"> </li>
+      <li>veteranStatus: <input type="text" name="veteranStatus"></li>
+      <li>countryOfResidence: <input type="text" name="countryOfResidence"> </li>
+      <li>addressLine1: <input type="text" name="addressLine1"></li>
+      <li>city: <input type="text" name="city"></li>
+      <li>state: <input type="text" name="state"></li>
+      <li>zip: <input type="text" name="zip" ></li>
+      <li>phoneNumber: <input type="text" name="phoneNumber"> </li>
+      <li>currentPrevStudent: <input type="text" name="currentPrevStudent"> </li>
+      <li>projectedEnrollment: <input type="text" name="projectedEnrollment">*</li>
+      <li>collegeOfInterest: <input type="text" name="collegeOfInterest">*</li>
+      <li>poiCode: <input type="text" name="poiCode">*</li>
+      <li>source_id: <input type="text" name="source_id" value="86"></li>
+      <li>online: <input type="text" name="online"></li>
+      <li>trackingId: <input type="text" name="trackingId"></li>
+      <li>questions: <input type="text" name="questions"></li>
+      <li>degreeLevel: <input type="text" name="degreeLevel" value="ugrad"></li>
+
+      <input type="hidden" name="testmode" value="Test">
+      <input type="hidden" name="formUrl" value="{{ redirect_back_url }}">
+      <input type="hidden" name="source_id" value="86">
+      
+      <li><input type="submit" value="Submit"></li>
+</ul>
+    </form>

--- a/src/views/rfi-form/form.handlebars
+++ b/src/views/rfi-form/form.handlebars
@@ -1,6 +1,6 @@
 <form method="post" action="https://requestinfo-qa.asu.edu/routing_form_post">
-<ul>
-      <li>First: <input type="text" name="firstName" value="foo">*</li>
+  <ul>
+      <li>First: <input type="text" name="firstName" value="{{ first_name }}">*</li>
       <li>Last: <input type="text" name="lastName">*</li>
       <li>Birthdate: <input type="text" name="birthdate"></li>
       <li>Email: <input type="text" name="emailAddress">*</li>
@@ -16,16 +16,15 @@
       <li>projectedEnrollment: <input type="text" name="projectedEnrollment">*</li>
       <li>collegeOfInterest: <input type="text" name="collegeOfInterest">*</li>
       <li>poiCode: <input type="text" name="poiCode">*</li>
-      <li>source_id: <input type="text" name="source_id" value="86"></li>
       <li>online: <input type="text" name="online"></li>
       <li>trackingId: <input type="text" name="trackingId"></li>
       <li>questions: <input type="text" name="questions"></li>
       <li>degreeLevel: <input type="text" name="degreeLevel" value="ugrad"></li>
 
-      <input type="hidden" name="testmode" value="Test">
+      <input type="hidden" name="testmode" value="{{ testmode }}">
       <input type="hidden" name="formUrl" value="{{ redirect_back_url }}">
-      <input type="hidden" name="source_id" value="86">
-      
+      <input type="hidden" name="source_id" value="{{ source_id }}">
+
       <li><input type="submit" value="Submit"></li>
-</ul>
-    </form>
+  </ul>
+</form>

--- a/src/views/rfi-form/form.handlebars
+++ b/src/views/rfi-form/form.handlebars
@@ -22,19 +22,19 @@
       <div class="form-group required has-feedback">
         <label class="control-label col-sm-3" for="firstName">First Name</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" id="firstName" name="firstName" value="{{ first_name }}" placeholder="First Name" maxlength="40">
+          <input type="text" class="form-control" id="firstName" name="firstName" value="{{ first_name }}" placeholder="First Name" maxlength="40" required aria-required="true">
         </div>
       </div>
       <div class="form-group required has-feedback">
         <label class="control-label col-sm-3" for="lastName">Last Name</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" id="lastName" name="lastName" value="{{ last_name }}" placeholder="Last Name" maxlength="50">
+          <input type="text" class="form-control" id="lastName" name="lastName" value="{{ last_name }}" placeholder="Last Name" maxlength="50" required aria-required="true">
         </div>
       </div>
       <div class="form-group required has-feedback">
         <label class="control-label col-sm-3" for="emailAddress">Email</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" id="emailAddress" name="emailAddress" value="{{ email }}" placeholder="Email@example.com" maxlength="50">
+          <input type="text" class="form-control" id="emailAddress" name="emailAddress" value="{{ email }}" placeholder="Email@example.com" maxlength="50" required aria-required="true">
         </div>
       </div>
       <div class="form-group has-feedback">
@@ -116,7 +116,7 @@
       <div class="form-group has-feedback required">
         <label class="control-label col-sm-3" for="collegeOfInterest">Program code</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" id="collegeOfInterest" name="collegeOfInterest" value="{{ collegeOfInterest }}" placeholder='' maxlength="4"> {{!-- TODO: needs to be a dropdown of Degree codes (e.g. UGBA or GRHI ) --}}
+          <input type="text" class="form-control" id="collegeOfInterest" name="collegeOfInterest" value="{{ collegeOfInterest }}" placeholder='' maxlength="4"> {{!-- TODO: needs to be a dropdown of Degree codes (e.g. UGBA or GRHI ) and a required field --}}
         </div>
       </div>
       <div class="form-group has-feedback required">
@@ -146,16 +146,16 @@
           </select>
         </div>
       </div>
-      <div class="form-group has-feedback required">
+      <div class="form-group has-feedback">
         <label class="control-label col-sm-3" for="question">Additional Questions?</label>
         <div class="col-sm-9">
           <textarea type="text" class="form-control" id="question" name="question" maxlength="500"></textarea>
         </div>
       </div>
-      <div class="form-group has-feedback">
-        <label class="control-label col-sm-3" for="submit"></label>
+      <div class="form-group">
+        <div class="col-sm-3"></div>
         <div class="col-sm-9">
-          <input type="submit" value="Submit" class="btn btn-default">
+          <input type="submit" value="Submit" class="btn btn-default" aria-label="Submit Request">
         </div>
       </div>
 </form>

--- a/src/views/rfi-form/form.handlebars
+++ b/src/views/rfi-form/form.handlebars
@@ -1,3 +1,16 @@
+{{#if success_message }}
+  <div class="alert alert-success" role="alert">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    {{ success_message }}
+  </div>
+{{/if}}
+{{#if error_message }}
+  <div class="alert alert-danger" role="alert">
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    {{ error_message }}
+  </div>
+{{/if}}
+
 <form method="post" action="https://requestinfo-qa.asu.edu/routing_form_post" class="form-horizontal">
 
     <input type="hidden" name="degreeLevel" value="{{ degreeLevel }}">

--- a/src/views/rfi-form/form.handlebars
+++ b/src/views/rfi-form/form.handlebars
@@ -102,10 +102,15 @@
           <input type="text" class="form-control" id="currentPrevStudent" name="currentPrevStudent" value="{{ currentPrevStudent }}">
         </div>
       </div> -->
-      <div class="form-group has-feedback required">
+      <div class="form-group optional has-feedback">
         <label class="control-label col-sm-3" for="projectedEnrollment">Projected Enrollment Term</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" id="projectedEnrollment" name="projectedEnrollment" value="{{ projectedEnrollment }}" placeholder=''> {{!-- TODO: needs to be a dropdown of peoplesoft codes --}}
+          <select name="projectedEnrollment" id="projectedEnrollment" class="form-select">
+            <option value="" selected="selected">-</option>
+            {{#each enrollment_terms }}
+              <option value="{{ value }}">{{ label }}</option>
+            {{/each}}
+          </select>
         </div>
       </div>
       <div class="form-group has-feedback required">

--- a/src/views/rfi-form/form.handlebars
+++ b/src/views/rfi-form/form.handlebars
@@ -134,7 +134,7 @@
           <textarea type="text" class="form-control" id="question" name="question" maxlength="500"></textarea>
         </div>
       </div>
-      <div class="form-group has-feedback required">
+      <div class="form-group has-feedback">
         <label class="control-label col-sm-3" for="submit"></label>
         <div class="col-sm-9">
           <input type="submit" value="Submit" class="btn btn-default">

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -62,7 +62,7 @@
       </div>
       
       
-      <div class="form-group has-feedback">
+      <div class="form-group">
         <div class="col-sm-3"></div>
         <div class="col-sm-9">
           <input type="submit" value="Submit" class="btn btn-default" aria-label="Submit Request">

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -22,19 +22,19 @@
       <div class="form-group required has-feedback">
         <label class="control-label col-sm-3" for="firstName">First Name</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" id="firstName" name="firstName" value="{{ first_name }}" placeholder="First Name" maxlength="40">
+          <input type="text" class="form-control" id="firstName" name="firstName" value="{{ first_name }}" placeholder="First Name" maxlength="40" required>
         </div>
       </div>
       <div class="form-group required has-feedback">
         <label class="control-label col-sm-3" for="lastName">Last Name</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" id="lastName" name="lastName" value="{{ last_name }}" placeholder="Last Name" maxlength="50">
+          <input type="text" class="form-control" id="lastName" name="lastName" value="{{ last_name }}" placeholder="Last Name" maxlength="50" required>
         </div>
       </div>
       <div class="form-group required has-feedback">
         <label class="control-label col-sm-3" for="emailAddress">Email</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" id="emailAddress" name="emailAddress" value="{{ email }}" placeholder="Email@example.com" maxlength="50">
+          <input type="email" class="form-control" id="emailAddress" name="emailAddress" value="{{ email }}" placeholder="Email@example.com" maxlength="50" required>
         </div>
       </div>
       <div class="form-group optional has-feedback">
@@ -46,7 +46,7 @@
       <div class="form-group has-feedback required">
         <label class="control-label col-sm-3" for="question">Question?</label>
         <div class="col-sm-9">
-          <textarea type="text" class="form-control" id="question" name="question" maxlength="500"></textarea>
+          <textarea type="text" class="form-control" id="question" name="question" maxlength="500" required></textarea>
         </div>
       </div>
       <div class="form-group optional has-feedback">
@@ -69,3 +69,5 @@
         </div>
       </div>
 </form>
+{{> rfi-form/form-javascript }}
+

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -37,7 +37,7 @@
           <input type="text" class="form-control" id="emailAddress" name="emailAddress" value="{{ email }}" placeholder="Email@example.com" maxlength="50">
         </div>
       </div>
-      <div class="form-group has-feedback">
+      <div class="form-group optional has-feedback">
         <label class="control-label col-sm-3" for="phoneNumber">Phone</label>
         <div class="col-sm-9">
           <input type="text" class="form-control" id="phoneNumber" name="phoneNumber" value="{{ phoneNumber }}" placeholder='(123) 456-7890' maxlength="30">
@@ -49,25 +49,25 @@
           <textarea type="text" class="form-control" id="question" name="question" maxlength="500"></textarea>
         </div>
       </div>
-      <div class="form-group has-feedback">
+      <div class="form-group optional has-feedback">
         <label class="control-label col-sm-3" for="projectedEnrollment">Projected Enrollment Term</label>
         <div class="col-sm-9">
           <input type="text" class="form-control" id="projectedEnrollment" name="projectedEnrollment" value="{{ projectedEnrollment }}" placeholder=''> {{!-- TODO: needs to be a dropdown of peoplesoft codes --}}
         </div>
       </div>
-      <div class="form-group has-feedback">
+      <div class="form-group optional has-feedback">
         <label class="control-label col-sm-3" for="collegeOfInterest">Program code</label>
         <div class="col-sm-9">
           <input type="text" class="form-control" id="collegeOfInterest" name="collegeOfInterest" value="{{ collegeOfInterest }}" placeholder='' maxlength="4"> {{!-- TODO: needs to be a dropdown of Degree codes (e.g. UGBA or GRHI ) --}}
         </div>
       </div>
-      <div class="form-group has-feedback">
+      <div class="form-group optional has-feedback">
         <label class="control-label col-sm-3" for="poiCode">Plan code</label>
         <div class="col-sm-9">
           <input type="text" class="form-control" id="poiCode" name="poiCode" value="{{ poiCode }}" placeholder='' maxlength="10"> {{!-- TODO: needs to be a dropdown of valid plan codes, please check Degree Search for valid codes (e.g. BAFULLMBA) --}}
         </div>
       </div>
-      <div class="form-group has-feedback">
+      <div class="form-group optional has-feedback">
         <label class="control-label col-sm-3" for="StudentType">Student Type</label>
         <div class="col-sm-9">
           <select name="StudentType" id="StudentType" class="form-select">

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -50,30 +50,7 @@
         </div>
       </div>
       <div class="form-group optional has-feedback">
-        <label class="control-label col-sm-3" for="projectedEnrollment">Projected Enrollment Term</label>
-        <div class="col-sm-9">
-          <select name="projectedEnrollment" id="projectedEnrollment" class="form-select">
-            <option value="" selected="selected">-</option>
-            {{#each enrollment_terms }}
-              <option value="{{ value }}">{{ label }}</option>
-            {{/each}}
-          </select>
-        </div>
-      </div>
-      <div class="form-group optional has-feedback">
-        <label class="control-label col-sm-3" for="collegeOfInterest">Program code</label>
-        <div class="col-sm-9">
-          <input type="text" class="form-control" id="collegeOfInterest" name="collegeOfInterest" value="{{ collegeOfInterest }}" placeholder='' maxlength="4"> {{!-- TODO: needs to be a dropdown of Degree codes (e.g. UGBA or GRHI ) --}}
-        </div>
-      </div>
-      <div class="form-group optional has-feedback">
-        <label class="control-label col-sm-3" for="poiCode">Plan code</label>
-        <div class="col-sm-9">
-          <input type="text" class="form-control" id="poiCode" name="poiCode" value="{{ poiCode }}" placeholder='' maxlength="10"> {{!-- TODO: needs to be a dropdown of valid plan codes, please check Degree Search for valid codes (e.g. BAFULLMBA) --}}
-        </div>
-      </div>
-      <div class="form-group optional has-feedback">
-        <label class="control-label col-sm-3" for="StudentType">Student Type</label>
+        <label class="control-label col-sm-3" for="StudentType">I am going to be a</label>
         <div class="col-sm-9">
           <select name="StudentType" id="StudentType" class="form-select">
             <option value="" selected="selected">-</option>

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -38,83 +38,30 @@
         </div>
       </div>
       <div class="form-group has-feedback">
-        <label class="control-label col-sm-3" for="birthdate">Birthdate</label>
-        <div class="col-sm-9">
-          <input type="date" class="form-control" id="birthdate" name="birthdate" value="{{ email }}" placeholder="YYYY-MM-DD"> {{!-- TODO: polyfil date picker --}}
-        </div>
-      </div>
-      <div class="form-group has-feedback">
-        <label class="control-label col-sm-3" for="countryOfCitizenship">Country Of Citizenship</label>
-        <div class="col-sm-9">
-          <input type="text" class="form-control" id="countryOfCitizenship" name="countryOfCitizenship" value="{{ countryOfCitizenship }}">
-        </div>
-      </div>
-      <div class="form-group has-feedback">
-        <label class="control-label col-sm-3" for="veteranStatus">US Military/Veteran Status</label>
-        <div class="col-sm-9">
-          <select name="veteranStatus" id="veteranStatus" class="form-select">
-            <option value="" selected="selected">- None -</option>
-            <option value="member">I am a service member or a veteran</option>
-            <option value="dependent">I am a spouse or dependent of a service member or a veteran</option>
-          </select>
-        </div>
-      </div>
-      <div class="form-group has-feedback">
-        <label class="control-label col-sm-3" for="countryOfResidence">Country Of Residence</label>
-        <div class="col-sm-9">
-          <input type="text" class="form-control" id="countryOfResidence" name="countryOfResidence" value="{{ countryOfResidence }}">
-        </div>
-      </div>
-      <div class="form-group has-feedback">
-        <label class="control-label col-sm-3" for="addressLine1">Address</label>
-        <div class="col-sm-9">
-          <input type="text" class="form-control" id="addressLine1" name="addressLine1" value="{{ addressLine1 }}" maxlength="50">
-        </div>
-      </div>
-      <div class="form-group has-feedback">
-        <label class="control-label col-sm-3" for="city">City</label>
-        <div class="col-sm-9">
-          <input type="text" class="form-control" id="city" name="city" value="{{ city }}" maxlength="40">
-        </div>
-      </div>
-      <div class="form-group has-feedback">
-        <label class="control-label col-sm-3" for="state">State</label>
-        <div class="col-sm-9">
-          <input type="text" class="form-control" id="state" name="state" value="{{ state }}" maxlength="40">
-        </div>
-      </div>
-      <div class="form-group has-feedback">
-        <label class="control-label col-sm-3" for="zip">Zip Code</label>
-        <div class="col-sm-9">
-          <input type="text" class="form-control" id="zip" name="zip" value="{{ zip }}" maxlength="20">
-        </div>
-      </div>
-      <div class="form-group has-feedback">
         <label class="control-label col-sm-3" for="phoneNumber">Phone</label>
         <div class="col-sm-9">
           <input type="text" class="form-control" id="phoneNumber" name="phoneNumber" value="{{ phoneNumber }}" placeholder='(123) 456-7890' maxlength="30">
         </div>
       </div>
-{{!-- Not a documented feild???      --}}
-      <!-- <div class="form-group has-feedback">
-        <label class="control-label col-sm-3" for="currentPrevStudent">Current or Previous Student?</label>
-        <div class="col-sm-9">
-          <input type="text" class="form-control" id="currentPrevStudent" name="currentPrevStudent" value="{{ currentPrevStudent }}">
-        </div>
-      </div> -->
       <div class="form-group has-feedback required">
+        <label class="control-label col-sm-3" for="question">Question?</label>
+        <div class="col-sm-9">
+          <textarea type="text" class="form-control" id="question" name="question" maxlength="500"></textarea>
+        </div>
+      </div>
+      <div class="form-group has-feedback">
         <label class="control-label col-sm-3" for="projectedEnrollment">Projected Enrollment Term</label>
         <div class="col-sm-9">
           <input type="text" class="form-control" id="projectedEnrollment" name="projectedEnrollment" value="{{ projectedEnrollment }}" placeholder=''> {{!-- TODO: needs to be a dropdown of peoplesoft codes --}}
         </div>
       </div>
-      <div class="form-group has-feedback required">
+      <div class="form-group has-feedback">
         <label class="control-label col-sm-3" for="collegeOfInterest">Program code</label>
         <div class="col-sm-9">
           <input type="text" class="form-control" id="collegeOfInterest" name="collegeOfInterest" value="{{ collegeOfInterest }}" placeholder='' maxlength="4"> {{!-- TODO: needs to be a dropdown of Degree codes (e.g. UGBA or GRHI ) --}}
         </div>
       </div>
-      <div class="form-group has-feedback required">
+      <div class="form-group has-feedback">
         <label class="control-label col-sm-3" for="poiCode">Plan code</label>
         <div class="col-sm-9">
           <input type="text" class="form-control" id="poiCode" name="poiCode" value="{{ poiCode }}" placeholder='' maxlength="10"> {{!-- TODO: needs to be a dropdown of valid plan codes, please check Degree Search for valid codes (e.g. BAFULLMBA) --}}
@@ -131,22 +78,8 @@
           </select>
         </div>
       </div>
-      <div class="form-group has-feedback">
-        <label class="control-label col-sm-3" for="online">Interested in taking Online courses?</label>
-        <div class="col-sm-9">
-          <select name="online" id="online" class="form-select">
-            <option value="" selected="selected">-</option>
-            <option value="Yes">Yes</option>
-            <option value="No">No</option>
-          </select>
-        </div>
-      </div>
-      <div class="form-group has-feedback required">
-        <label class="control-label col-sm-3" for="question">Additional Questions?</label>
-        <div class="col-sm-9">
-          <textarea type="text" class="form-control" id="question" name="question" maxlength="500"></textarea>
-        </div>
-      </div>
+      
+      
       <div class="form-group has-feedback">
         <label class="control-label col-sm-3" for="submit"></label>
         <div class="col-sm-9">

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -22,19 +22,19 @@
       <div class="form-group required has-feedback">
         <label class="control-label col-sm-3" for="firstName">First Name</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" id="firstName" name="firstName" value="{{ first_name }}" placeholder="First Name" maxlength="40" required>
+          <input type="text" class="form-control" id="firstName" name="firstName" value="{{ first_name }}" placeholder="First Name" maxlength="40" required aria-required="true">
         </div>
       </div>
       <div class="form-group required has-feedback">
         <label class="control-label col-sm-3" for="lastName">Last Name</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" id="lastName" name="lastName" value="{{ last_name }}" placeholder="Last Name" maxlength="50" required>
+          <input type="text" class="form-control" id="lastName" name="lastName" value="{{ last_name }}" placeholder="Last Name" maxlength="50" required aria-required="true">
         </div>
       </div>
       <div class="form-group required has-feedback">
         <label class="control-label col-sm-3" for="emailAddress">Email</label>
         <div class="col-sm-9">
-          <input type="email" class="form-control" id="emailAddress" name="emailAddress" value="{{ email }}" placeholder="Email@example.com" maxlength="50" required>
+          <input type="email" class="form-control" id="emailAddress" name="emailAddress" value="{{ email }}" placeholder="Email@example.com" maxlength="50" required aria-required="true">
         </div>
       </div>
       <div class="form-group optional has-feedback">
@@ -46,7 +46,7 @@
       <div class="form-group has-feedback required">
         <label class="control-label col-sm-3" for="question">Question?</label>
         <div class="col-sm-9">
-          <textarea type="text" class="form-control" id="question" name="question" maxlength="500" required></textarea>
+          <textarea type="text" class="form-control" id="question" name="question" maxlength="500" required aria-required="true"></textarea>
         </div>
       </div>
       <div class="form-group optional has-feedback">
@@ -63,9 +63,9 @@
       
       
       <div class="form-group has-feedback">
-        <label class="control-label col-sm-3" for="submit"></label>
+        <div class="col-sm-3"></div>
         <div class="col-sm-9">
-          <input type="submit" value="Submit" class="btn btn-default">
+          <input type="submit" value="Submit" class="btn btn-default" aria-label="Submit Request">
         </div>
       </div>
 </form>

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -52,7 +52,12 @@
       <div class="form-group optional has-feedback">
         <label class="control-label col-sm-3" for="projectedEnrollment">Projected Enrollment Term</label>
         <div class="col-sm-9">
-          <input type="text" class="form-control" id="projectedEnrollment" name="projectedEnrollment" value="{{ projectedEnrollment }}" placeholder=''> {{!-- TODO: needs to be a dropdown of peoplesoft codes --}}
+          <select name="projectedEnrollment" id="projectedEnrollment" class="form-select">
+            <option value="" selected="selected">-</option>
+            {{#each enrollment_terms }}
+              <option value="{{ value }}">{{ label }}</option>
+            {{/each}}
+          </select>
         </div>
       </div>
       <div class="form-group optional has-feedback">

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,6 +17,7 @@ require_once $_tests_dir . '/includes/functions.php';
  * Manually load the plugin being tested.
  */
 function _manually_load_plugin() {
+  require dirname( __FILE__ ) . '/data-loader.php';
 	require dirname( dirname( __FILE__ ) ) . '/asu-rfi-wordpress-plugin.php';
 }
 tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );

--- a/tests/data-loader.php
+++ b/tests/data-loader.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Data Loader - Any plugin setup for testing (for enabling/disabling features)
+ */
+
+update_option(
+    'asu-rfi-options',
+    array(
+      'source_id' => 999,
+    )
+);

--- a/tests/unit/test-address-service.php
+++ b/tests/unit/test-address-service.php
@@ -12,8 +12,8 @@ use ASURFIWordPress\Services\AddressService;
  */
 class AddressTestService extends WP_UnitTestCase {
 
-  function test_getCountries() {
-    $countries = AddressService::getCountries();
+  function test_get_countries() {
+    $countries = AddressService::get_countries();
     $this->assertInternalType('array', $countries);
     $this->assertNotEmpty($countries);
     $this->assertGreaterThan(200, count($countries), 'there should be more than 200 countries'); 

--- a/tests/unit/test-address-service.php
+++ b/tests/unit/test-address-service.php
@@ -17,8 +17,22 @@ class AddressTestService extends WP_UnitTestCase {
     $this->assertInternalType('array', $countries);
     $this->assertNotEmpty($countries);
     $this->assertGreaterThan(200, count($countries), 'there should be more than 200 countries'); 
-    $this->assertNotNull($countries[0]['name']);
-    $this->assertNotNull($countries[0]['code']);
+
+    $first_country = current($countries);
+    $this->assertNotNull($first_country['name']);
+    $this->assertNotNull($first_country['code']);
   }
+
+  function test_get_states() {
+    $states = AddressService::get_states( 'US' );
+    $this->assertInternalType('array', $states);
+    $this->assertNotEmpty($states);
+    $this->assertGreaterThan(50, count($states), 'there should be more than 50 US states'); 
+
+    $first_state = current($states);
+    $this->assertNotNull($first_state['name']);
+    $this->assertNotNull($first_state['code']);
+  }
+
 
 }

--- a/tests/unit/test-address-service.php
+++ b/tests/unit/test-address-service.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Class AddressTestService
+ *
+ * @package Asu_Rfi_Wordpress_Plugin
+ */
+
+use ASURFIWordPress\Services\AddressService;
+
+/**
+ * Address Service test cases
+ */
+class AddressTestService extends WP_UnitTestCase {
+
+  function test_getCountries() {
+    $countries = AddressService::getCountries();
+    $this->assertInternalType('array', $countries);
+    $this->assertNotEmpty($countries);
+    $this->assertGreaterThan(200, count($countries), 'there should be more than 200 countries'); 
+    $this->assertNotNull($countries[0]['name']);
+    $this->assertNotNull($countries[0]['code']);
+  }
+
+}

--- a/tests/unit/test-asu-degree-service.php
+++ b/tests/unit/test-asu-degree-service.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Class ASUDegreeServiceTest
+ *
+ * @package Asu_Rfi_Wordpress_Plugin
+ */
+use ASURFIWordPress\Services\ASUDegreeService;
+
+/**
+ * ASUDegreeService test case.
+ */
+class ASUDegreeServiceTest extends WP_UnitTestCase {
+
+  function test_get_available_enrollment_terms() {
+    $service = new ASUDegreeService();
+    $terms = $service->get_available_enrollment_terms();
+    $this->assertInternalType('array', $terms);
+    $this->assertGreaterThan(4, count($terms), 'there should be more than 4 terms'); 
+    print_r($terms);
+    
+  }
+}

--- a/tests/unit/test-asu-degree-service.php
+++ b/tests/unit/test-asu-degree-service.php
@@ -12,8 +12,7 @@ use ASURFIWordPress\Services\ASUDegreeService;
 class ASUDegreeServiceTest extends WP_UnitTestCase {
 
   function test_get_available_enrollment_terms() {
-    $service = new ASUDegreeService();
-    $terms = $service->get_available_enrollment_terms();
+    $terms = ASUDegreeService::get_available_enrollment_terms();
     $this->assertInternalType('array', $terms);
     $this->assertGreaterThan(4, count($terms), 'there should be more than 4 terms');    
   }

--- a/tests/unit/test-asu-degree-service.php
+++ b/tests/unit/test-asu-degree-service.php
@@ -15,8 +15,13 @@ class ASUDegreeServiceTest extends WP_UnitTestCase {
     $service = new ASUDegreeService();
     $terms = $service->get_available_enrollment_terms();
     $this->assertInternalType('array', $terms);
-    $this->assertGreaterThan(4, count($terms), 'there should be more than 4 terms'); 
-    print_r($terms);
-    
+    $this->assertGreaterThan(4, count($terms), 'there should be more than 4 terms');    
+  }
+
+  function test_get_colleges() {
+    $service = new ASUDegreeService();
+    $colleges = $service->get_colleges();
+    $this->assertInternalType('array', $colleges);
+    $this->assertGreaterThan(4, count($colleges), 'there should be more than 4 colleges');  
   }
 }

--- a/tests/unit/test-shortcodes.php
+++ b/tests/unit/test-shortcodes.php
@@ -22,5 +22,17 @@ class ShortCodesTest extends WP_UnitTestCase {
     $this->assertContains('<form', $result);
   }
 
+  function test_shortcode_uses_source_id_from_db() {
+    $source_id_default_in_db = 999; // see data-loader.php
+
+    $result = do_shortcode( '[asu-rfi-form]' );
+    $this->assertContains('value="'.$source_id_default_in_db.'"', $result);
+  }
+
+  function test_shortcode_uses_source_id_from_attribute_over_db() {
+    $result = do_shortcode( '[asu-rfi-form source_id=12345]' );
+    $this->assertContains('value="12345"', $result);
+  }
+
 
 }

--- a/tests/unit/test-shortcodes.php
+++ b/tests/unit/test-shortcodes.php
@@ -38,7 +38,7 @@ class ShortCodesTest extends WP_UnitTestCase {
     $result = do_shortcode( '[asu-rfi-form]' );
     $this->assertContains('name="testmode" value="Prod"', $result);
   }
-  
+
   function test_shortcode_default_test_mode() {
     $result = do_shortcode( '[asu-rfi-form test_mode="test"]' );
     $this->assertContains('name="testmode" value="Test"', $result);

--- a/tests/unit/test-shortcodes.php
+++ b/tests/unit/test-shortcodes.php
@@ -17,7 +17,7 @@ class ShortCodesTest extends WP_UnitTestCase {
     $this->assertTrue( shortcode_exists( 'asu-rfi-form' ) );
   }
 
-  function test_shortcode_returns_something() {
+  function test_shortcode_returns_a_form() {
     $result = do_shortcode( '[asu-rfi-form]' );
     $this->assertContains('<form', $result);
   }

--- a/tests/unit/test-shortcodes.php
+++ b/tests/unit/test-shortcodes.php
@@ -26,13 +26,22 @@ class ShortCodesTest extends WP_UnitTestCase {
     $source_id_default_in_db = 999; // see data-loader.php
 
     $result = do_shortcode( '[asu-rfi-form]' );
-    $this->assertContains('value="'.$source_id_default_in_db.'"', $result);
+    $this->assertContains('name="source_id" value="'.$source_id_default_in_db.'"', $result);
   }
 
   function test_shortcode_uses_source_id_from_attribute_over_db() {
     $result = do_shortcode( '[asu-rfi-form source_id=12345]' );
-    $this->assertContains('value="12345"', $result);
+    $this->assertContains('name="source_id" value="12345"', $result);
   }
 
+  function test_shortcode_default_test_mode() {
+    $result = do_shortcode( '[asu-rfi-form]' );
+    $this->assertContains('name="testmode" value="Prod"', $result);
+  }
+  
+  function test_shortcode_default_test_mode() {
+    $result = do_shortcode( '[asu-rfi-form test_mode="test"]' );
+    $this->assertContains('name="testmode" value="Test"', $result);
+  }
 
 }

--- a/tests/unit/test-shortcodes.php
+++ b/tests/unit/test-shortcodes.php
@@ -39,7 +39,7 @@ class ShortCodesTest extends WP_UnitTestCase {
     $this->assertContains('name="testmode" value="Prod"', $result);
   }
 
-  function test_shortcode_default_test_mode() {
+  function test_shortcode_test_mode() {
     $result = do_shortcode( '[asu-rfi-form test_mode="test"]' );
     $this->assertContains('name="testmode" value="Test"', $result);
   }

--- a/tests/unit/test-shortcodes.php
+++ b/tests/unit/test-shortcodes.php
@@ -16,4 +16,11 @@ class ShortCodesTest extends WP_UnitTestCase {
   function test_asu_rfi_form_shortcode_exists() {
     $this->assertTrue( shortcode_exists( 'asu-rfi-form' ) );
   }
+
+  function test_shortcode_returns_something() {
+    $result = do_shortcode( '[asu-rfi-form]' );
+    $this->assertContains('<form', $result);
+  }
+
+
 }


### PR DESCRIPTION
This should be the bare minimum to get the basic "ask a question" short form working. Nothing glamorous yet, just enough to get shipped and we can work on improving it as we go.

This plugin adds a shortcode `[asu-rfi-form]` and a settings page for defining the `source_id` for the side.

Todo:
- [x] client side validation of fields
- [x] cache control settings
- [x] site wide settings for source_id


![screen shot 2016-12-12 at 3 38 20 pm](https://cloud.githubusercontent.com/assets/295804/21119802/6a034bc2-c081-11e6-8d86-c5d55b0efc9c.png)

Success Banner:
![screen shot 2016-12-12 at 3 38 35 pm](https://cloud.githubusercontent.com/assets/295804/21119803/6a1b5802-c081-11e6-8cad-f68d76ac8039.png)

Error Banner:
![screen shot 2016-12-12 at 3 42 14 pm](https://cloud.githubusercontent.com/assets/295804/21119834/951a8384-c081-11e6-9f35-6d228c794be6.png)

Settings Menu Location:
![screen shot 2016-12-13 at 12 43 24 pm](https://cloud.githubusercontent.com/assets/295804/21156084/c728ccae-c131-11e6-8e0f-7cbc1a6e3db6.png)
