### PR TITLE
major selection options

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ WordPress plugin to submit Request For Information requests into Salesforce
 # Site Settings
 ![screen shot 2016-12-13 at 12 43 24 pm](https://cloud.githubusercontent.com/assets/295804/21156084/c728ccae-c131-11e6-8e0f-7cbc1a6e3db6.png)
 
-**source_id** You will need to uptain a orignal source identifier from the [ASU Enrollment Services Department](mailto:ecomm@asu.edu) for your college or department.
+**source_id** You will need to obtain a orignal source identifier from the [ASU Enrollment Services Department](mailto:ecomm@asu.edu) for your college or department.
 
 **College Code** 2-5 character string, usually all caps, eg `LA` for `College of Liberal Arts and Sciences` or `SU` for `School of Sustainability`. This will be the default college used for RFI forms on the site.
 

--- a/README.md
+++ b/README.md
@@ -14,22 +14,21 @@ WordPress plugin to submit Request For Information requests into Salesforce
 
 **source_id** You will need to uptain a orignal source identifier from the [ASU Enrollment Services Department](mailto:ecomm@asu.edu) for your college or department.
 
-**College Code** 2-5 character string, usually all caps, like `LA` for `College of Liberal Arts and Sciences` or `SU` for `School of Sustainability`. This will be the default college used for RFI forms on the site.
+**College Code** 2-5 character string, usually all caps, eg `LA` for `College of Liberal Arts and Sciences` or `SU` for `School of Sustainability`. This will be the default college used for RFI forms on the site.
 
 
 # Shortcodes
 
 `[asu-rfi-form]` - For displaying an Request For Information form.
 * attributes:
-   *     type = 'full' or leave blank for the default simple form
-   *     degree_level = 'ugrad' or 'grad' Default is 'ugrad', (alternative spellings `undergraduate` and `graduate` will also work)
-   *     test_mode = 'test' or leave blank for the default production
-   *     major_code = eg 'SUSMSUS' - for hard coding a specific major for a form
-   *     major_code_picker = 'true' to enable, leave off or blank to disable showing a drop down of majors based on the campus, school and degree level specified. 
-   *     source_id = integer site identifier (issued by Enrollment services department) will default to the site wide setting made in the admin options.
-   *     college_program_code = 2-5 character string, usually all caps, like `LA` for `College of Liberal Arts and Sciences` or `SU` for `School of Sustainability`, it will default to the value set in the RFI Admin Options menu so only use this attribute if you want to override one specific form.
-   *     campus    = eg 'TEMPE' or leave blank for all Campuses.
+   *     **type** = `full` or leave blank for the default simple form
+   *     **degree_level** = `ugrad` or `grad` Default is `ugrad`, (alternative spellings `undergraduate` and `graduate` will also work)
+   *     **test_mode** = `test` or leave blank for the default production
+   *     **major_code** = eg `SUSMSUS` - for hard coding a specific major for a form
+   *     **major_code_picker** = `true` to enable, leave off or blank to disable showing a drop down of majors based on the campus, school and degree level specified. 
+   *     **source_id** = integer site identifier (issued by Enrollment services department) will default to the site wide setting made in the admin options.
+   *     **college_program_code** = 2-5 character string, usually all caps, eg `LA` for `College of Liberal Arts and Sciences` or `SU` for `School of Sustainability`, it will default to the value set in the RFI Admin Options menu so only use this attribute if you want to override one specific form.
+   *     **campus** = eg `TEMPE` or leave blank for all Campuses.
    *
 
-![screen shot 2016-12-12 at 3 38 20 pm](https://cloud.githubusercontent.com/assets/295804/21119802/6a034bc2-c081-11e6-8d86-c5d55b0efc9c.png)
-
+![screen shot 2017-01-30 at 4 55 33 pm](https://cloud.githubusercontent.com/assets/295804/22447084/86dfca7e-e70d-11e6-862f-3373b29064e4.png)

--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ WordPress plugin to submit Request For Information requests into Salesforce
 # Requirements
 * php > 5.5 
 * [GitHub Updater WordPress Plugin](https://github.com/afragen/github-updater)
+* The active theme should have a recent verson of Twitter Boostrap.
 
 
 # Site Settings
-**source_id** you need to uptain a orignal source identifier from the [ASU Enrollment Services Department](mailto:ecomm@asu.edu) for your college or department.
-
 ![screen shot 2016-12-13 at 12 43 24 pm](https://cloud.githubusercontent.com/assets/295804/21156084/c728ccae-c131-11e6-8e0f-7cbc1a6e3db6.png)
+
+**source_id** You will need to uptain a orignal source identifier from the [ASU Enrollment Services Department](mailto:ecomm@asu.edu) for your college or department.
+
+**College Code** 2-5 character string, usually all caps, like `LA` for `College of Liberal Arts and Sciences` or `SU` for `School of Sustainability`. This will be the default college used for RFI forms on the site.
 
 
 # Shortcodes
@@ -19,9 +22,14 @@ WordPress plugin to submit Request For Information requests into Salesforce
 `[asu-rfi-form]` - For displaying an Request For Information form.
 * attributes:
    *     type = 'full' or leave blank for the default simple form
-   *     degree_level = 'ugrad' or 'grad' Default is 'ugrad'
+   *     degree_level = 'ugrad' or 'grad' Default is 'ugrad', (alternative spellings `undergraduate` and `graduate` will also work)
    *     test_mode = 'test' or leave blank for the default production
-   *     source_id = integer site identifier (issued by Enrollment services department) will default to site wide setting
+   *     major_code = eg 'SUSMSUS' - for hard coding a specific major for a form
+   *     major_code_picker = 'true' to enable, leave off or blank to disable showing a drop down of majors based on the campus, school and degree level specified. 
+   *     source_id = integer site identifier (issued by Enrollment services department) will default to the site wide setting made in the admin options.
+   *     college_program_code = 2-5 character string, usually all caps, like `LA` for `College of Liberal Arts and Sciences` or `SU` for `School of Sustainability`, it will default to the value set in the RFI Admin Options menu so only use this attribute if you want to override one specific form.
+   *     campus    = eg 'TEMPE' or leave blank for all Campuses.
+   *
 
 ![screen shot 2016-12-12 at 3 38 20 pm](https://cloud.githubusercontent.com/assets/295804/21119802/6a034bc2-c081-11e6-8d86-c5d55b0efc9c.png)
 

--- a/asu-rfi-wordpress-plugin.php
+++ b/asu-rfi-wordpress-plugin.php
@@ -21,6 +21,8 @@ if ( ! function_exists( 'add_filter' ) ) {
 
 define( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION', '0.0.1' );
 
+define( 'ASU_DIRECTORY_XML_RPC_SERVER', 'https://webapp4.asu.edu/programs/XmlRpcServer');
+
 require __DIR__ . '/vendor/autoload.php';
 
 $registry = new \Honeycomb\Services\Register();

--- a/src/admin/asu-rfi-admin-page.php
+++ b/src/admin/asu-rfi-admin-page.php
@@ -19,6 +19,7 @@ class ASU_RFI_Admin_Page extends Hook {
   public static $options_name = 'asu-rfi-options';
   public static $options_group = 'asu-rfi-options_group';
   public static $source_id_option_name = 'source_id';
+  public static $college_code_option_name = 'college_code';
   public static $section_id = 'asu-rfi-section_id';
   public static $section_name = 'asu-rfi-section_name';
   public static $page_name = 'asu-rfi-admin-page';
@@ -34,6 +35,7 @@ class ASU_RFI_Admin_Page extends Hook {
         self::$options_name,
         array(
           self::$source_id_option_name => 0,
+          self::$college_code_option_name => null,
         )
     );
 
@@ -76,6 +78,17 @@ class ASU_RFI_Admin_Page extends Hook {
         array(
           $this,
           'source_id_on_callback',
+        ), // Callback
+        self::$section_name,
+        self::$section_id
+    );
+
+    add_settings_field(
+        self::$college_code_option_name,
+        'Default College Code',
+        array(
+          $this,
+          'college_code_on_callback',
         ), // Callback
         self::$section_name,
         self::$section_id
@@ -123,7 +136,35 @@ class ASU_RFI_Admin_Page extends Hook {
   }
 
   /**
-   * Print the form section for the research group slugs
+   * Print the form section for the college code
+   */
+  public function college_code_on_callback() {
+
+    $value = $this->get_option_attribute_or_default(
+        array(
+          'name'      => self::$options_name,
+          'attribute' => self::$college_code_option_name,
+          'default'   => '',
+        )
+    );
+
+    $html = <<<HTML
+    <input type="text" id="%s" name="%s[%s]" value="%s"/><br/>
+    <em>College Codes are used in the class program catalog, they usually are two or three characters long and in all caps. Also they can be found with `GR` or `UG` prefixes (for undergraduate or graduate courses), leave that prefix off.</em><br/>
+    <span>Example: <strong>SU</strong> for `The School of Sustainbility`</span>
+HTML;
+
+    printf(
+        $html,
+        self::$college_code_option_name,
+        self::$options_name,
+        self::$college_code_option_name,
+        $value
+    );
+  }
+
+  /**
+   * Print the form section for the source_id form element
    */
   public function source_id_on_callback() {
 
@@ -148,7 +189,6 @@ HTML;
         self::$source_id_option_name,
         $value
     );
-
   }
 
   /**
@@ -159,6 +199,11 @@ HTML;
     if ( isset( $input[ self::$source_id_option_name ] ) ) {
       $input[ self::$source_id_option_name ] = intval( $input[ self::$source_id_option_name ] );
     }
+
+    if ( isset( $input[ self::$college_code_option_name ] ) ) {
+      $input[ self::$college_code_option_name ] = strtoupper( $input[ self::$college_code_option_name ] );
+    }
+
     return $input;
   }
 

--- a/src/helpers/conditional-helpers.php
+++ b/src/helpers/conditional-helpers.php
@@ -10,45 +10,44 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
   exit();
 }
 
-/** Helpers for conditionals that get repeated 
- *
+/** Helpers for conditionals that get repeated
  */
 class ConditionalHelper {
 
 
-	/** 
+	/** Graduate? 
    * return true if the input is any one of the ways you might spell graduate
    */
 	public static function graduate( $input ) {
-    if( 0 === strcasecmp( 'grad', $input ) ||
+    if ( 0 === strcasecmp( 'grad', $input ) ||
         0 === strcasecmp( 'graduate', $input ) ) {
       return true;
-    } 
+    }
     return false;
   }
 
 
-  /** 
+  /** UnderGraduate?
    * return true if the input is any one of the ways you might spell undergraduate
    */
   public static function undergraduate( $input ) {
-    if( 0 === strcasecmp( 'ugrad', $input ) ||
+    if ( 0 === strcasecmp( 'ugrad', $input ) ||
         0 === strcasecmp( 'undergrad', $input ) ||
         0 === strcasecmp( 'undergraduate', $input ) ) {
       return true;
-    } 
+    }
     return false;
   }
 
-  /** 
+  /** Online?
    * return true if the input is any one of the ways you might spell online
    */
   public static function online( $input ) {
-    if( 0 === strcasecmp( 'ONLNE', $input ) ||
+    if ( 0 === strcasecmp( 'ONLNE', $input ) ||
         0 === strcasecmp( 'on-line', $input ) ||
         0 === strcasecmp( 'online', $input ) ) {
       return true;
-    } 
+    }
     return false;
   }
 

--- a/src/helpers/conditional-helpers.php
+++ b/src/helpers/conditional-helpers.php
@@ -15,9 +15,9 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
 class ConditionalHelper {
 
 
-	/** Graduate? 
-   * return true if the input is any one of the ways you might spell graduate
-   */
+	/** Graduate?
+     * return true if the input is any one of the ways you might spell graduate
+     */
 	public static function graduate( $input ) {
     if ( 0 === strcasecmp( 'grad', $input ) ||
         0 === strcasecmp( 'graduate', $input ) ) {

--- a/src/helpers/conditional-helpers.php
+++ b/src/helpers/conditional-helpers.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace ASURFIWordPress\Helpers;
+
+
+// Avoid direct calls to this file
+if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
+  header( 'Status: 403 Forbidden' );
+  header( 'HTTP/1.1 403 Forbidden' );
+  exit();
+}
+
+/** Helpers for conditionals
+ *
+ */
+class ConditionalHelper {
+
+
+	/** 
+   * return true if the input is any one of the ways you might spell graduate
+   */
+	public static function graduate( $input ) {
+    if( 0 === strcasecmp( 'grad', $input ) ||
+        0 === strcasecmp( 'graduate', $input ) ) {
+      return true;
+    } 
+    return false;
+  }
+
+
+  /** 
+   * return true if the input is any one of the ways you might spell undergraduate
+   */
+  public static function undergraduate( $input ) {
+    if( 0 === strcasecmp( 'ugrad', $input ) ||
+        0 === strcasecmp( 'undergrad', $input ) ||
+        0 === strcasecmp( 'undergraduate', $input ) ) {
+      return true;
+    } 
+    return false;
+  }
+
+}

--- a/src/helpers/conditional-helpers.php
+++ b/src/helpers/conditional-helpers.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
   exit();
 }
 
-/** Helpers for conditionals
+/** Helpers for conditionals that get repeated 
  *
  */
 class ConditionalHelper {

--- a/src/helpers/conditional-helpers.php
+++ b/src/helpers/conditional-helpers.php
@@ -40,4 +40,16 @@ class ConditionalHelper {
     return false;
   }
 
+  /** 
+   * return true if the input is any one of the ways you might spell online
+   */
+  public static function online( $input ) {
+    if( 0 === strcasecmp( 'ONLNE', $input ) ||
+        0 === strcasecmp( 'on-line', $input ) ||
+        0 === strcasecmp( 'online', $input ) ) {
+      return true;
+    } 
+    return false;
+  }
+
 }

--- a/src/services/asu-campus-service.php
+++ b/src/services/asu-campus-service.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
 
 /** Campus Service - services for the Various ASU Campuses
  */
-class CampusService {
+class ASUCampusService {
 
 	/** Get Campus codes as defined by http://www.public.asu.edu/~lcabre/javadocs/dsws/
 	 *	Since there is no actual endpoint to get these, we'll have to hardcode them here.

--- a/src/services/asu-college-service.php
+++ b/src/services/asu-college-service.php
@@ -5,6 +5,8 @@ namespace ASURFIWordPress\Services;
 use PhpXmlRpc\Value;
 use PhpXmlRpc\Request;
 use PhpXmlRpc\Client;
+use ASURFIWordPress\Helpers\ConditionalHelper;
+
 
 // Avoid direct calls to this file
 if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
@@ -48,4 +50,30 @@ class ASUCollegeService {
     $response = $this->client->send( $request );
     return $response->val->me['string'];
   }
+
+
+  /** Optionally append either UG or GR to the program_code if neither is already defined.
+   * Since the postfix is the same for Undergraduate (UG) and Graduate (GR) programs then lets  
+   * add it if it gets ommited. 
+   */
+  public static function add_degree_level_prefix( $program_code, $degree_level ) {
+    $program_code = strtoupper( $program_code ); // they should all be UPPER CASE
+
+    if ( ConditionalHelper::graduate( $degree_level ) ) {
+      if( starts_with( $program_code, 'GR' ) ) {
+        return $program_code;
+      } else {
+        return 'GR'.$program_code;
+      }
+    } else {
+       if( starts_with( $program_code, 'UG' ) ) {
+        return $program_code;
+      } else {
+        return 'UG'.$program_code;
+      }
+    }
+    return $program_code;
+  }
+
+
 }

--- a/src/services/asu-college-service.php
+++ b/src/services/asu-college-service.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace ASURFIWordPress\Services;
+
+use PhpXmlRpc\Value;
+use PhpXmlRpc\Request;
+use PhpXmlRpc\Client;
+
+// Avoid direct calls to this file
+if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
+  header( 'Status: 403 Forbidden' );
+  header( 'HTTP/1.1 403 Forbidden' );
+  exit();
+}
+
+/**
+ * College Information Service for ASU
+ */
+class ASUCollegeService {
+
+  public function __construct( $client = null ) {
+    if ( null === $client ) {
+      $client = new Client( ASU_DIRECTORY_XML_RPC_SERVER );
+    }
+    $this->client = $client;
+  }
+
+  /** Get Colleges Display names in an array 
+   * 
+   */
+  public function get_colleges() {
+    $request = new Request( 'eAdvisorDSFind.listColleges' );
+    $response = $this->client->send( $request );
+    return array_map( function( $item ) {
+        return array( 'name' => $item->me['string'] );
+    }, $response->val->me['array'] );
+
+  }
+
+  /** Get College code given the display name 
+   *  eg: given 'Sustainability, School of' this will return 'CSS', 
+   * Note: this is not the same as the college code in the program!
+   */
+  public function get_college_code( $college_name ) {
+    $request = new Request( 'eAdvisorDSFind.getCollegeCodeForName', 
+      array(
+        new Value( $college_name, 'string' ) 
+    ) );
+    $response = $this->client->send( $request );
+    return $response->val->me['string'];
+  }
+}

--- a/src/services/asu-college-service.php
+++ b/src/services/asu-college-service.php
@@ -60,7 +60,7 @@ class ASUCollegeService {
     $program_code = strtoupper( $program_code ); // they should all be UPPER CASE
 
     // Base Case: empty strings should return empty strings
-    if ( 1 > strlen( $program_code ) ) { 
+    if ( 1 > strlen( $program_code ) ) {
       return $program_code;
     }
 

--- a/src/services/asu-college-service.php
+++ b/src/services/asu-college-service.php
@@ -53,23 +53,23 @@ class ASUCollegeService {
 
 
   /** Optionally append either UG or GR to the program_code if neither is already defined.
-   * Since the postfix is the same for Undergraduate (UG) and Graduate (GR) programs then lets  
-   * add it if it gets ommited. 
+   * Since the postfix is the same for Undergraduate (UG) and Graduate (GR) programs then lets
+   * add it if it gets ommited.
    */
   public static function add_degree_level_prefix( $program_code, $degree_level ) {
     $program_code = strtoupper( $program_code ); // they should all be UPPER CASE
 
     if ( ConditionalHelper::graduate( $degree_level ) ) {
-      if( starts_with( $program_code, 'GR' ) ) {
+      if ( starts_with( $program_code, 'GR' ) ) {
         return $program_code;
       } else {
-        return 'GR'.$program_code;
+        return 'GR' . $program_code;
       }
     } else {
-       if( starts_with( $program_code, 'UG' ) ) {
+       if ( starts_with( $program_code, 'UG' ) ) {
         return $program_code;
       } else {
-        return 'UG'.$program_code;
+        return 'UG' . $program_code;
       }
     }
     return $program_code;

--- a/src/services/asu-college-service.php
+++ b/src/services/asu-college-service.php
@@ -25,8 +25,7 @@ class ASUCollegeService {
     $this->client = $client;
   }
 
-  /** Get Colleges Display names in an array 
-   * 
+  /** Get Colleges Display names in an array
    */
   public function get_colleges() {
     $request = new Request( 'eAdvisorDSFind.listColleges' );
@@ -37,14 +36,14 @@ class ASUCollegeService {
 
   }
 
-  /** Get College code given the display name 
-   *  eg: given 'Sustainability, School of' this will return 'CSS', 
+  /** Get College code given the display name
+   *  eg: given 'Sustainability, School of' this will return 'CSS',
    * Note: this is not the same as the college code in the program!
    */
   public function get_college_code( $college_name ) {
-    $request = new Request( 'eAdvisorDSFind.getCollegeCodeForName', 
-      array(
-        new Value( $college_name, 'string' ) 
+    $request = new Request( 'eAdvisorDSFind.getCollegeCodeForName',
+        array(
+        new Value( $college_name, 'string' )
     ) );
     $response = $this->client->send( $request );
     return $response->val->me['string'];

--- a/src/services/asu-college-service.php
+++ b/src/services/asu-college-service.php
@@ -40,7 +40,7 @@ class ASUCollegeService {
 
   /** Get College code given the display name
    *  eg: given 'Sustainability, School of' this will return 'CSS',
-   * Note: this is not the same as the college code for the programs!! 
+   * Note: this is not the same as the college code for the programs!!
    */
   public function get_college_code( $college_name ) {
     $request = new Request( 'eAdvisorDSFind.getCollegeCodeForName',
@@ -60,7 +60,9 @@ class ASUCollegeService {
     $program_code = strtoupper( $program_code ); // they should all be UPPER CASE
 
     // Base Case: empty strings should return empty strings
-    if( 1 > strlen($program_code) ) return $program_code;
+    if ( 1 > strlen( $program_code ) ) { 
+      return $program_code;
+    }
 
     if ( ConditionalHelper::graduate( $degree_level ) ) {
       if ( starts_with( $program_code, 'GR' ) ) {

--- a/src/services/asu-college-service.php
+++ b/src/services/asu-college-service.php
@@ -40,7 +40,7 @@ class ASUCollegeService {
 
   /** Get College code given the display name
    *  eg: given 'Sustainability, School of' this will return 'CSS',
-   * Note: this is not the same as the college code in the program!
+   * Note: this is not the same as the college code for the programs!! 
    */
   public function get_college_code( $college_name ) {
     $request = new Request( 'eAdvisorDSFind.getCollegeCodeForName',
@@ -58,6 +58,9 @@ class ASUCollegeService {
    */
   public static function add_degree_level_prefix( $program_code, $degree_level ) {
     $program_code = strtoupper( $program_code ); // they should all be UPPER CASE
+
+    // Base Case: empty strings should return empty strings
+    if( 1 > strlen($program_code) ) return $program_code;
 
     if ( ConditionalHelper::graduate( $degree_level ) ) {
       if ( starts_with( $program_code, 'GR' ) ) {

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -83,6 +83,51 @@ class ASUDegreeService {
   // }
 
   public function get_programs( $college ) {
+    // $request = new Request( 'eAdvisorDSFind.findDegreeByCampusMapArray' );
+    // $response = $this->client->send( $request );
+    // return array_map( function( $item ) {
+    //     return array( 'name' => $item->me['string'] );
+    // }, $response->val->me['array'] );
+
+  }
+
+  /**
+   * the response object is rather obscure to work with, it looks like this:
+   * 
+   PhpXmlRpc\Response Object (
+    [val] => PhpXmlRpc\Value Object
+        ( [me] => Array (
+            [array] => Array (
+                [0] => PhpXmlRpc\Value Object (
+                    [me] => Array (
+                        [struct] => Array (
+                            [AcadCareer] => PhpXmlRpc\Value Object (
+                                [me] => Array (
+                                    [string] => "blah blah"
+                                )
+                              )
+                              ....
+
+   */
+  public function get_programs_per_campus( $campus = 'TEMPE', $program = 'graduate' ) {
+    $request = new Request( 'eAdvisorDSFind.findDegreeByCampusMapArray', array(
+       new Value( $campus, 'string' ), 
+       new Value( $program, 'string'), 
+       new Value(FALSE, 'boolean')) );
+
+    $response = $this->client->send( $request );
+    $value = $response->value()->me;
+    $value = array_pop($value);
+    
+    return array_map( function( $item ) {
+      $program = $item->me['struct'];
+        return array( 
+          'majorcode'   => $program['AcadPlan']->me['string'],
+          'majorname'   => $program['Descr100']->me['string'],
+          'programname' => $program['DiplomaDescr']->me['string'],
+          'programcode' => $program['AcadProg']->me['string'],
+         );
+    }, $value );
 
   }
 

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -6,7 +6,7 @@ use PhpXmlRpc\Value;
 use PhpXmlRpc\Request;
 use PhpXmlRpc\Client;
 use ASURFIWordPress\Helpers\ConditionalHelper;
-use ASURFIWordPress\Services\CampusService;
+use ASURFIWordPress\Services\ASUCampusService;
 
 // Avoid direct calls to this file
 if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
@@ -29,40 +29,7 @@ class ASUDegreeService {
     $this->client = $client;
   }
 
-  /*
-   * enrollment terms
-   * These are the peoplesoft term identifiers
-   *  "2101" for Spring, 2010, or  3
-   *  "2104" for Summer, 2010, or  3
-   *  "2107" for Fall, 2010, or  2
-   *  "2109" for Winter, 2010
-   *  "2177" for Summer, 2017
-   */
-  public static function get_available_enrollment_terms() {
-    $semester_names = array(
-      1 => 'Spring',
-      4 => 'Summer',
-      7 => 'Fall',
-      9 => 'Winter',
-    );
-
-    // TODO: this obviously should be more dynamic but it will do for the next few years
-    $years = array( '2017', '2018', '2019' );
-    $terms = array();
-
-    foreach ( $years as $year ) {
-      foreach ( $semester_names as $semester_key => $semester_name ) {
-        $terms[] = array(
-          'value' => self::get_peoplesoft_semester_code( $year, $semester_key ),
-          'label' => $semester_name . ' ' . $year,
-        );
-      }
-    }
-
-    return $terms;
-  }
-
-  /*
+  /**
    * get_peoplesoft_semester_code( $year, $semester_number ):
    * Given $year='2017', $semester_number = '4'
    * returns '2174'
@@ -77,7 +44,7 @@ class ASUDegreeService {
    */
   public function get_programs_on_all_campuses( $degree_level = 'graduate' ) {
     $results = array();
-    $campuses = CampusService::get_campus_codes();
+    $campuses = ASUCampusService::get_campus_codes();
     foreach ( $campuses as $campus_code ) {
       $results_for_this_campus = $this->get_programs_per_campus( $degree_level, $campus_code );
       $results = array_merge( $results, $results_for_this_campus );

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -22,11 +22,10 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
  * @group asu-degree-service
  */
 class ASUDegreeService {
-  const ASU_DIRECTORY_XML_RPC_SERVER = 'https://webapp4.asu.edu/programs/XmlRpcServer';
 
   public function __construct( $client = null ) {
     if ( null === $client ) {
-      $client = new Client( self::ASU_DIRECTORY_XML_RPC_SERVER );
+      $client = new Client( ASU_DIRECTORY_XML_RPC_SERVER );
     }
     $this->client = $client;
   }
@@ -83,14 +82,14 @@ class ASUDegreeService {
   // );
   // }
 
-  public function get_programs( $college ) {
-    // $request = new Request( 'eAdvisorDSFind.findDegreeByCampusMapArray' );
-    // $response = $this->client->send( $request );
-    // return array_map( function( $item ) {
-    //     return array( 'name' => $item->me['string'] );
-    // }, $response->val->me['array'] );
+  // public function get_programs_on_all_campuses( $college ) {
+  //   // $request = new Request( 'eAdvisorDSFind.findDegreeByCampusMapArray' );
+  //   // $response = $this->client->send( $request );
+  //   // return array_map( function( $item ) {
+  //   //     return array( 'name' => $item->me['string'] );
+  //   // }, $response->val->me['array'] );
 
-  }
+  // }
 
   /**
    * the response object is rather obscure to work with, it looks like this:
@@ -119,11 +118,11 @@ class ASUDegreeService {
     }
 
     if( ConditionalHelper::online( $campus ) ) { 
-      // They want Online to be spelled this way..
+      // They want Online to be spelled this way. 
       $campus = 'ONLNE';
     }
 
-    
+
     $request = new Request( 'eAdvisorDSFind.findDegreeByCampusMapArray', 
       array(
         new Value( $campus, 'string' ), 
@@ -148,6 +147,9 @@ class ASUDegreeService {
 
   }
 
+  /** Get major programs 
+   *
+   */
   public function get_majors_per_college($college_code, $degree_level = 'graduate', $campus = 'TEMPE' ) {
     $programs = $this->get_programs_per_campus( $degree_level , $campus ); 
     $subset = array(); 
@@ -155,7 +157,7 @@ class ASUDegreeService {
     foreach( $programs as $program ) {
       if ( 0 === strcasecmp( $college_code, $program['programcode'] ) ) {
         $subset []= array( 
-          'label' => $this->get_display_name( $program ),
+          'label' => $this->get_program_display_name( $program ),
           'value' => $program['majorcode'],
          );
       }
@@ -163,19 +165,10 @@ class ASUDegreeService {
     return $subset;
   }
 
-  public function get_colleges() {
-    $request = new Request( 'eAdvisorDSFind.listColleges' );
-    $response = $this->client->send( $request );
-    return array_map( function( $item ) {
-        return array( 'name' => $item->me['string'] );
-    }, $response->val->me['array'] );
-
-  }
-
-  /** get_display_name( $program ) - if needed, append in () the last two digets
+  /** get_program_display_name( $program ) - if needed, append in () the last two digets
    * of the majorcode unless there is a () in the major name already.
    */
-  private function get_display_name( $program ) {
+  private function get_program_display_name( $program ) {
     if ( strpos( $program['majorname'], '(' ) === FALSE ) {
       $last_two_letters_of_major_code = substr($program['majorcode'], -2 );
       return $program['majorname']." (".$last_two_letters_of_major_code.")";          

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -138,10 +138,16 @@ class ASUDegreeService {
 
   }
 
-  /** Get major programs
+  /** Get major programs for a college at a degree level and optionally for a campus.
+   * if no campus is defined than all campuses are returned.
    */
-  public function get_majors_per_college( $college_code, $degree_level = 'graduate', $campus = 'TEMPE' ) {
-    $programs = $this->get_programs_per_campus( $degree_level , $campus );
+  public function get_majors_per_college( $college_code, $degree_level = 'graduate', $campus = null ) {
+    if( null === $campus ) {
+      $programs = $this->get_programs_on_all_campuses( $degree_level );
+    } else {
+      $programs = $this->get_programs_per_campus( $degree_level , $campus );
+    }
+    
     return $this->filter_programs_for_a_college( $college_code, $programs );
   }
 
@@ -152,13 +158,17 @@ class ASUDegreeService {
 
     foreach ( $all_programs as $program ) {
       if ( 0 === strcasecmp( $college_code, $program['programcode'] ) ) {
-        $subset [] = array(
+        $formatted_program = array(
           'label' => $this->get_program_display_name( $program ),
           'value' => $program['majorcode'],
          );
+        // there could be duplicate programs offered on multiple campuses
+        if( !in_array($formatted_program, $subset) ) {
+          $subset [] = $formatted_program;  
+        }
       }
     }
-    return $subset;
+    return $subset; 
   }
 
   /** Get a programs Display Name( $program ) - if needed, append in () the last two digets

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -142,12 +142,12 @@ class ASUDegreeService {
    * if no campus is defined than all campuses are returned.
    */
   public function get_majors_per_college( $college_code, $degree_level = 'graduate', $campus = null ) {
-    if( null === $campus ) {
+    if ( null === $campus ) {
       $programs = $this->get_programs_on_all_campuses( $degree_level );
     } else {
       $programs = $this->get_programs_per_campus( $degree_level , $campus );
     }
-    
+
     return $this->filter_programs_for_a_college( $college_code, $programs );
   }
 
@@ -163,12 +163,12 @@ class ASUDegreeService {
           'value' => $program['majorcode'],
          );
         // there could be duplicate programs offered on multiple campuses
-        if( !in_array($formatted_program, $subset) ) {
-          $subset [] = $formatted_program;  
+        if ( ! in_array( $formatted_program, $subset ) ) {
+          $subset [] = $formatted_program;
         }
       }
     }
-    return $subset; 
+    return $subset;
   }
 
   /** Get a programs Display Name( $program ) - if needed, append in () the last two digets

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -142,7 +142,7 @@ class ASUDegreeService {
    * if no campus is defined than all campuses are returned.
    */
   public function get_majors_per_college( $college_code, $degree_level = 'graduate', $campus = null ) {
-    if ( null === $campus ) {
+    if ( empty( $campus ) ) {
       $programs = $this->get_programs_on_all_campuses( $degree_level );
     } else {
       $programs = $this->get_programs_per_campus( $degree_level , $campus );

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -109,7 +109,7 @@ class ASUDegreeService {
                               ....
 
    */
-  public function get_programs_per_campus( $campus = 'TEMPE', $program = 'graduate' ) {
+  public function get_programs_per_campus( $program = 'graduate', $campus = 'TEMPE' ) {
     $request = new Request( 'eAdvisorDSFind.findDegreeByCampusMapArray', array(
        new Value( $campus, 'string' ), 
        new Value( $program, 'string'), 
@@ -129,6 +129,21 @@ class ASUDegreeService {
          );
     }, $value );
 
+  }
+
+  public function get_majors_per_college($college_code, $program = 'graduate', $campus = 'TEMPE' ) {
+    $programs = $this->get_programs_per_campus( $program , $campus ); 
+    $subset = array(); 
+    foreach($programs as $program) {
+      if($program['programcode'] == $college_code) {
+        $last_two_letters_of_major_code = substr($program['majorcode'], -2 );
+        $subset []= array( 
+          'label' => $program['majorname']." (".$last_two_letters_of_major_code.")",
+          'value' => $program['majorcode'],
+         );
+      }
+    }
+    return $subset;
   }
 
   public function get_colleges() {

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
  * XML RPC API Docs: http://www.public.asu.edu/~lcabre/javadocs/dsws/
  */
 class ASUDegreeService {
+  private static $RPC_TIMEOUT = 10; // seconds
 
   public function __construct( $client = null ) {
     if ( null === $client ) {
@@ -118,11 +119,14 @@ class ASUDegreeService {
         array(
         new Value( $campus, 'string' ),
         new Value( $program_to_search, 'string' ),
-        new Value( false, 'boolean' ),
+        new Value( false, 'boolean' ), // get both certificates and majors
         )
     );
 
-    $response = $this->client->send( $request );
+    $response = $this->client->send( $request, ASUDegreeService::$RPC_TIMEOUT );
+    if( ! empty( $response->errstr ) ) {
+      throw new \Exception('ASU Degree Service Error: '.$response->errno.': '.$response->errstr.' : '.ASU_DIRECTORY_XML_RPC_SERVER);
+    }
     $value = $response->value()->me;
     $value = array_pop( $value );
 

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -88,6 +88,7 @@ class ASUDegreeService {
   /** Get Programs offered on a specific Campus
    * the response object is rather obscure to work with, it looks like this:
    *
+   * @throws \Exception if unable to make RPC request
    PhpXmlRpc\Response Object (
     [val] => PhpXmlRpc\Value Object
         ( [me] => Array (
@@ -124,8 +125,8 @@ class ASUDegreeService {
     );
 
     $response = $this->client->send( $request, ASUDegreeService::$RPC_TIMEOUT );
-    if( ! empty( $response->errstr ) ) {
-      throw new \Exception('ASU Degree Service Error: '.$response->errno.': '.$response->errstr.' : '.ASU_DIRECTORY_XML_RPC_SERVER);
+    if ( ! empty( $response->errstr ) ) {
+      throw new \Exception( 'ASU Degree Service Error: ' . $response->errno . ': ' . $response->errstr . ' : ' . ASU_DIRECTORY_XML_RPC_SERVER );
     }
     $value = $response->value()->me;
     $value = array_pop( $value );

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -118,6 +118,12 @@ class ASUDegreeService {
       $program_to_search = 'undergrad';
     }
 
+    if( ConditionalHelper::online( $campus ) ) { 
+      // They want Online to be spelled this way..
+      $campus = 'ONLNE';
+    }
+
+    
     $request = new Request( 'eAdvisorDSFind.findDegreeByCampusMapArray', 
       array(
         new Value( $campus, 'string' ), 

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -29,15 +29,6 @@ class ASUDegreeService {
     $this->client = $client;
   }
 
-  /**
-   * get_peoplesoft_semester_code( $year, $semester_number ):
-   * Given $year='2017', $semester_number = '4'
-   * returns '2174'
-   */
-  private static function get_peoplesoft_semester_code( $year, $semester_number ) {
-    return substr( $year,0,1 ) . substr( $year,2,2 ) . $semester_number;
-  }
-
   /** Get all the programs across all campuses for a specific degree level in one array.
    * 'graduate' or 'undergraduate' are accepted values for degree levels.
    * returns an array.

--- a/src/services/asu-degree-service.php
+++ b/src/services/asu-degree-service.php
@@ -135,10 +135,9 @@ class ASUDegreeService {
     $programs = $this->get_programs_per_campus( $program , $campus ); 
     $subset = array(); 
     foreach($programs as $program) {
-      if($program['programcode'] == $college_code) {
-        $last_two_letters_of_major_code = substr($program['majorcode'], -2 );
+      if ( $program['programcode'] == $college_code) {
         $subset []= array( 
-          'label' => $program['majorname']." (".$last_two_letters_of_major_code.")",
+          'label' => $this->get_display_name( $program ),
           'value' => $program['majorcode'],
          );
       }
@@ -155,4 +154,16 @@ class ASUDegreeService {
 
   }
 
+  /** get_display_name( $program ) - if needed, append in () the last two digets
+   * of the majorcode unless there is a () in the major name already.
+   */
+  private function get_display_name( $program ) {
+    if ( strpos( $program['majorname'], '(' ) === FALSE ) {
+      $last_two_letters_of_major_code = substr($program['majorcode'], -2 );
+      return $program['majorname']." (".$last_two_letters_of_major_code.")";          
+    } else {
+      return $program['majorname'];
+    }
+
+  }
 }

--- a/src/services/asu-semester-service.php
+++ b/src/services/asu-semester-service.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
 class ASUSemesterService {
 
   /**
-   * enrollment terms
+   * Get Enrollment terms
    * These are the peoplesoft term identifiers
    *  "2101" for Spring, 2010, or  3
    *  "2104" for Summer, 2010, or  3
@@ -48,7 +48,7 @@ class ASUSemesterService {
   }
 
   /**
-   * get_peoplesoft_semester_code( $year, $semester_number ):
+   * Get peoplesoft Semester Codes given ( $year, $semester_number ):
    * Given $year='2017', $semester_number = '4'
    * returns '2174'
    */

--- a/src/services/asu-semester-service.php
+++ b/src/services/asu-semester-service.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace ASURFIWordPress\Services;
+
+// Avoid direct calls to this file
+if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
+  header( 'Status: 403 Forbidden' );
+  header( 'HTTP/1.1 403 Forbidden' );
+  exit();
+}
+
+/** ASU Semester Service
+ * Providing information on asu semesters
+ */
+class ASUSemesterService {
+
+  /**
+   * enrollment terms
+   * These are the peoplesoft term identifiers
+   *  "2101" for Spring, 2010, or  3
+   *  "2104" for Summer, 2010, or  3
+   *  "2107" for Fall, 2010, or  2
+   *  "2109" for Winter, 2010
+   *  "2177" for Summer, 2017
+   */
+  public static function get_available_enrollment_terms() {
+    $semester_names = array(
+      1 => 'Spring',
+      4 => 'Summer',
+      7 => 'Fall',
+      9 => 'Winter',
+    );
+
+    // TODO: this obviously should be more dynamic but it will do for the next few years
+    $years = array( '2017', '2018', '2019' );
+    $terms = array();
+
+    foreach ( $years as $year ) {
+      foreach ( $semester_names as $semester_key => $semester_name ) {
+        $terms[] = array(
+          'value' => self::get_peoplesoft_semester_code( $year, $semester_key ),
+          'label' => $semester_name . ' ' . $year,
+        );
+      }
+    }
+
+    return $terms;
+  }
+
+  /**
+   * get_peoplesoft_semester_code( $year, $semester_number ):
+   * Given $year='2017', $semester_number = '4'
+   * returns '2174'
+   */
+  private static function get_peoplesoft_semester_code( $year, $semester_number ) {
+    return substr( $year,0,1 ) . substr( $year,2,2 ) . $semester_number;
+  }
+}

--- a/src/services/campus-service.php
+++ b/src/services/campus-service.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ASURFIWordPress\Services;
+
+
+// Avoid direct calls to this file
+if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
+  header( 'Status: 403 Forbidden' );
+  header( 'HTTP/1.1 403 Forbidden' );
+  exit();
+}
+
+/** Campus Service - services for the Various ASU Campuses 
+ *
+ */
+class CampusService {
+
+	/* Get Campus codes as defined by http://www.public.asu.edu/~lcabre/javadocs/dsws/
+	 *	Since there is no actual endpoint to get these, we'll have to hardcode them here.
+	 */
+	publics static function get_campus_codes() {
+		// TODO: Thunderbird and Lake Havasu City campus? 
+		return array('TEMPE', 'POLY', 'DTPHX', 'WEST', 'ONLNE');
+	}
+
+}

--- a/src/services/campus-service.php
+++ b/src/services/campus-service.php
@@ -10,17 +10,17 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
   exit();
 }
 
-/** Campus Service - services for the Various ASU Campuses 
- *
+/** Campus Service - services for the Various ASU Campuses
  */
 class CampusService {
 
-	/* Get Campus codes as defined by http://www.public.asu.edu/~lcabre/javadocs/dsws/
+	/*
+	 Get Campus codes as defined by http://www.public.asu.edu/~lcabre/javadocs/dsws/
 	 *	Since there is no actual endpoint to get these, we'll have to hardcode them here.
 	 */
 	public static function get_campus_codes() {
-		// TODO: Thunderbird and Lake Havasu City campus? 
-		return array('TEMPE', 'POLY', 'DTPHX', 'WEST', 'ONLNE');
+		// TODO: Thunderbird and Lake Havasu City campus?
+		return array( 'TEMPE', 'POLY', 'DTPHX', 'WEST', 'ONLNE' );
 	}
 
 }

--- a/src/services/campus-service.php
+++ b/src/services/campus-service.php
@@ -18,7 +18,7 @@ class CampusService {
 	/* Get Campus codes as defined by http://www.public.asu.edu/~lcabre/javadocs/dsws/
 	 *	Since there is no actual endpoint to get these, we'll have to hardcode them here.
 	 */
-	publics static function get_campus_codes() {
+	public static function get_campus_codes() {
 		// TODO: Thunderbird and Lake Havasu City campus? 
 		return array('TEMPE', 'POLY', 'DTPHX', 'WEST', 'ONLNE');
 	}

--- a/src/services/campus-service.php
+++ b/src/services/campus-service.php
@@ -14,8 +14,7 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
  */
 class CampusService {
 
-	/*
-	 Get Campus codes as defined by http://www.public.asu.edu/~lcabre/javadocs/dsws/
+	/** Get Campus codes as defined by http://www.public.asu.edu/~lcabre/javadocs/dsws/
 	 *	Since there is no actual endpoint to get these, we'll have to hardcode them here.
 	 */
 	public static function get_campus_codes() {

--- a/src/services/student-type-service.php
+++ b/src/services/student-type-service.php
@@ -2,6 +2,8 @@
 
 namespace ASURFIWordPress\Services;
 
+use ASURFIWordPress\Helpers\ConditionalHelper;
+
 // Avoid direct calls to this file
 if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
   header( 'Status: 403 Forbidden' );
@@ -15,7 +17,21 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
  */
 class StudentTypeService {
 
-  public static function get_student_types() {
+  public static function get_student_types($grad_or_undergrad = null) {
+    if( ConditionalHelper::undergraduate( $grad_or_undergrad ) ) {
+      return array(
+          array( 'value' => 'Freshman', 'label' => 'Undergraduate Freshman Student' ),
+          array( 'value' => 'Transfer', 'label' => 'Undergraduate Transfer Student' ),
+        );
+    } else if(  ConditionalHelper::graduate(  $grad_or_undergrad ) ) {
+      return array(
+          array( 'value' => 'Masters',  'label' => 'Graduate Masters Student' ),
+          array( 'value' => 'Doctoral', 'label' => 'Graduate Doctoral Student' ),
+          array( 'value' => 'cert',     'label' => 'Graduate Certificate Student' ),
+          array( 'value' => 'nd',       'label' => 'Graduate Non-Degree Seeking Student' ),
+        );
+    }
+    // default to returning everything
     return array(
         array( 'value' => 'Freshman', 'label' => 'Undergraduate Freshman Student' ),
         array( 'value' => 'Transfer', 'label' => 'Undergraduate Transfer Student' ),

--- a/src/services/student-type-service.php
+++ b/src/services/student-type-service.php
@@ -17,13 +17,13 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
  */
 class StudentTypeService {
 
-  public static function get_student_types($grad_or_undergrad = null) {
-    if( ConditionalHelper::undergraduate( $grad_or_undergrad ) ) {
+  public static function get_student_types( $grad_or_undergrad = null ) {
+    if ( ConditionalHelper::undergraduate( $grad_or_undergrad ) ) {
       return array(
           array( 'value' => 'Freshman', 'label' => 'Undergraduate Freshman Student' ),
           array( 'value' => 'Transfer', 'label' => 'Undergraduate Transfer Student' ),
         );
-    } else if(  ConditionalHelper::graduate(  $grad_or_undergrad ) ) {
+    } elseif (  ConditionalHelper::graduate( $grad_or_undergrad ) ) {
       return array(
           array( 'value' => 'Masters',  'label' => 'Graduate Masters Student' ),
           array( 'value' => 'Doctoral', 'label' => 'Graduate Doctoral Student' ),

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -104,6 +104,10 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    *     degree_level = 'ugrad' or 'grad' Default is 'ugrad'
    *     test_mode = 'test' or leave blank for the default production
    *     source_id = integer site identifier (issued by Enrollment services department) will default to site wide setting
+   *     college_program_code = 4 character string, usually all caps, like 
+   *         "GRLA" for College of Liberal Arts and Sciences or "GRSU" for "School of Sustainability"  
+   *     major_code_picker = boolean, if true then programs for the college will be provided in a dropdown
+   *     major_code = string, if provided then no picker, just a hidden major code value 
    */
   public function asu_rfi_form( $atts, $content = '' ) {
     $view_data = array(
@@ -121,6 +125,8 @@ class ASU_RFI_Form_Shortcodes extends Hook {
           'enrollment_terms' => Services\ASUDegreeService::get_available_enrollment_terms(),
           'student_types' => Services\StudentTypeService::get_student_types(),
           'college_program_code' => null,
+          'major_code_picker' => false,
+          'major_code' => null,
         );
 
     if ( isset( $atts['test_mode'] ) && 0 === strcasecmp( 'test', $atts['test_mode'] ) ) {
@@ -141,6 +147,10 @@ class ASU_RFI_Form_Shortcodes extends Hook {
 
     if( isset( $atts['college_program_code'] ) ) {
       $view_data['college_program_code'] = $atts['college_program_code'];
+    }
+
+    if( isset( $atts['major_code_picker']) && $atts['major_code_picker']) {
+      $view_data['major_codes'] = Services\ASUDegreeSErvice::get_majors_per_college($atts['college_program_code']);
     }
 
     $view_data = $this->look_for_a_submission_response( $view_data );

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -104,7 +104,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    * Handle the shortcode [asu-rfi-form]
    *   attributes:
    *     type = 'full' or leave blank for the default simple form
-   *     degree_level = 'ugrad' or 'grad' Default is 'ugrad'
+   *     degree_level = 'undergrad' or 'grad' Default is 'undergrad'
    *     test_mode = 'test' or leave blank for the default production
    *     source_id = integer site identifier (issued by Enrollment services department) will default to site wide setting
    *     college_program_code = 2-5 character string, usually all caps, like
@@ -118,6 +118,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
   public function asu_rfi_form( $atts, $content = '' ) {
     ensure_default( $atts, 'campus', null );
     ensure_default( $atts, 'major_code', null );
+    ensure_default( $atts, 'degreeLevel', 'undergrad');
     ensure_default( $atts, 'college_program_code', $this->get_option_attribute_or_default(
         array(
                 'name'      => ASU_RFI_Admin_Page::$options_name,
@@ -135,7 +136,6 @@ class ASU_RFI_Form_Shortcodes extends Hook {
                 'default'   => 0,
               )
           ),
-          'degreeLevel' => 'ugrad', // default to undergrad
           'enrollment_terms' => ASUDegreeService::get_available_enrollment_terms(),
           'student_types' => StudentTypeService::get_student_types(),
           'college_program_code' => null,
@@ -155,10 +155,10 @@ class ASU_RFI_Form_Shortcodes extends Hook {
     }
 
     // Use the attribute source id over the sites option
-    if ( isset( $atts['degree_level'] ) && ConditionalHelper::graduate( $atts['degree_level'] ) ) {
+    if ( ConditionalHelper::graduate( $atts['degree_level'] ) ) {
       $view_data['degreeLevel'] = 'grad';
       $view_data['student_types'] = StudentTypeService::get_student_types( 'grad' );
-    } elseif ( isset( $atts['degree_level'] ) && ConditionalHelper::undergraduate( $atts['degree_level'] ) ) {
+    } elseif ( ConditionalHelper::undergraduate( $atts['degree_level'] ) ) {
       $view_data['degreeLevel'] = 'ugrad';
       $view_data['student_types'] = StudentTypeService::get_student_types( 'undergrad' );
     }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -116,9 +116,13 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    *          restricted down to just the majors offered on that particular campus.
    */
   public function asu_rfi_form( $atts, $content = '' ) {
+    // if there are no attributes passed then $atts is not an array, its a string
+    if( ! is_array( $atts ) ) {
+      $atts = array();
+    }
     ensure_default( $atts, 'campus', null );
     ensure_default( $atts, 'major_code', null );
-    ensure_default( $atts, 'degreeLevel', 'undergrad');
+    ensure_default( $atts, 'degree_level', 'undergrad');
     ensure_default( $atts, 'college_program_code', $this->get_option_attribute_or_default(
         array(
                 'name'      => ASU_RFI_Admin_Page::$options_name,

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -177,7 +177,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
         $view_data['major_codes'] = $service->get_majors_per_college(
             $atts['college_program_code'],
             $view_data['degreeLevel'],
-            $campus
+            $atts['campus']
           );
       }
     }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -117,9 +117,10 @@ class ASU_RFI_Form_Shortcodes extends Hook {
               )
           ),
           'testmode' => 'Prod', // default to production mode
-          'degreeLevel' => 'ugrad', // default to und
+          'degreeLevel' => 'ugrad', // default to undergrad
           'enrollment_terms' => Services\ASUDegreeService::get_available_enrollment_terms(),
           'student_types' => Services\StudentTypeService::get_student_types(),
+          'college_program_code' => null,
         );
 
     if ( isset( $atts['test_mode'] ) && 0 === strcasecmp( 'test', $atts['test_mode'] ) ) {
@@ -136,6 +137,10 @@ class ASU_RFI_Form_Shortcodes extends Hook {
          0 === strcasecmp( 'grad', $atts['degree_level'] ) ||
          0 === strcasecmp( 'graduate', $atts['degree_level'] ) ) ) {
       $view_data['degreeLevel'] = 'grad';
+    }
+
+    if( isset( $atts['college_program_code'] ) ) {
+      $view_data['college_program_code'] = $atts['college_program_code'];
     }
 
     $view_data = $this->look_for_a_submission_response( $view_data );

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -146,7 +146,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
       $view_data['student_types'] = Services\StudentTypeService::get_student_types('grad');
     } else if ( isset( $atts['degree_level'] ) && ConditionalHelper::undergraduate( $atts['degree_level']) ) {
       $view_data['degreeLevel'] = 'ugrad';
-      $view_data['student_types'] = Services\StudentTypeService::get_student_types('ugrad');
+      $view_data['student_types'] = Services\StudentTypeService::get_student_types('undergrad');
     }
 
     if( isset( $atts['college_program_code'] ) ) {
@@ -154,7 +154,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
 
       if( isset( $atts['major_code_picker'] ) ) {
         $service = new Services\ASUDegreeService();
-        $view_data['major_codes'] = $service->get_majors_per_college($atts['college_program_code']);
+        $view_data['major_codes'] = $service->get_majors_per_college( $atts['college_program_code'], $view_data['degreeLevel']);
       }
     }
 

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -109,8 +109,11 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    *         "GRLA" for College of Liberal Arts and Sciences or "GRSU" for "School of Sustainability"
    *     major_code_picker = boolean, if true then programs for the college will be provided in a dropdown
    *     major_code = string, if provided then no picker, just a hidden major code value
+   *     campus = string, default is all campuses, if provided the major_code_picker will be 
+   *          restricted down to just the majors offered on that particular campus.
    */
   public function asu_rfi_form( $atts, $content = '' ) {
+    ensure_default($atts, 'campus', null);
 
     $view_data = array(
           'form_endpoint' => self::DEVELOPMENT_FORM_ENDPOINT,
@@ -154,7 +157,10 @@ class ASU_RFI_Form_Shortcodes extends Hook {
 
       if ( isset( $atts['major_code_picker'] ) ) {
         $service = new Services\ASUDegreeService();
-        $view_data['major_codes'] = $service->get_majors_per_college( $atts['college_program_code'], $view_data['degreeLevel'] );
+        $view_data['major_codes'] = $service->get_majors_per_college( 
+          $atts['college_program_code'], 
+          $view_data['degreeLevel'], 
+          $campus );
       }
     }
 

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -168,7 +168,8 @@ class ASU_RFI_Form_Shortcodes extends Hook {
 
       $atts['college_program_code'] = ASUCollegeService::add_degree_level_prefix(
           $atts['college_program_code'],
-      $view_data['degreeLevel']);
+          $view_data['degreeLevel']
+      );
 
       $view_data['college_program_code'] = $atts['college_program_code'];
 
@@ -178,7 +179,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
             $atts['college_program_code'],
             $view_data['degreeLevel'],
             $atts['campus']
-          );
+        );
       }
     }
 

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -118,12 +118,12 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    */
   public function asu_rfi_form( $atts, $content = '' ) {
     // if there are no attributes passed then $atts is not an array, its a string
-    if( ! is_array( $atts ) ) {
+    if ( ! is_array( $atts ) ) {
       $atts = array();
     }
     ensure_default( $atts, 'campus', null );
     ensure_default( $atts, 'major_code', null );
-    ensure_default( $atts, 'degree_level', 'undergrad');
+    ensure_default( $atts, 'degree_level', 'undergrad' );
     ensure_default( $atts, 'college_program_code', $this->get_option_attribute_or_default(
         array(
                 'name'      => ASU_RFI_Admin_Page::$options_name,

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -4,6 +4,7 @@ use Honeycomb\Wordpress\Hook;
 use ASURFIWordPress\Services\ASUDegreeService;
 use ASURFIWordPress\Services\StudentTypeService;
 use ASURFIWordPress\Services\ASUCollegeService;
+use ASURFIWordPress\Services\ASUSemesterService;
 use ASURFIWordPress\Stores\ASUDegreeStore;
 use ASURFIWordPress\Admin\ASU_RFI_Admin_Page;
 use ASURFIWordPress\Helpers\ConditionalHelper;
@@ -141,7 +142,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
                 'default'   => 0,
               )
           ),
-          'enrollment_terms' => ASUDegreeService::get_available_enrollment_terms(),
+          'enrollment_terms' => ASUSemesterService::get_available_enrollment_terms(),
           'student_types' => StudentTypeService::get_student_types(),
           'college_program_code' => null,
           'major_code_picker' => false,

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -4,6 +4,7 @@ use Honeycomb\Wordpress\Hook;
 use ASURFIWordPress\Services\ASUDegreeService;
 use ASURFIWordPress\Services\StudentTypeService;
 use ASURFIWordPress\Services\ASUCollegeService;
+use ASURFIWordPress\Stores\ASUDegreeStore;
 use ASURFIWordPress\Admin\ASU_RFI_Admin_Page;
 use ASURFIWordPress\Helpers\ConditionalHelper;
 
@@ -178,8 +179,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
       $view_data['college_program_code'] = $atts['college_program_code'];
 
       if ( isset( $atts['major_code_picker'] ) ) {
-        $service = new ASUDegreeService();
-        $view_data['major_codes'] = $service->get_majors_per_college(
+        $view_data['major_codes'] = ASUDegreeStore::get_programs(
             $atts['college_program_code'],
             $view_data['degreeLevel'],
             $atts['campus']

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -106,15 +106,15 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    *     test_mode = 'test' or leave blank for the default production
    *     source_id = integer site identifier (issued by Enrollment services department) will default to site wide setting
    *     college_program_code = 2-5 character string, usually all caps, like
-   *         "LA" for College of Liberal Arts and Sciences or "SU" for "School of Sustainability" 
+   *         "LA" for College of Liberal Arts and Sciences or "SU" for "School of Sustainability"
    *     major_code_picker = boolean, if true then programs for the college will be provided in a dropdown
    *     major_code = string, if provided then no picker, just a hidden major code value
-   *     campus = string, default is all campuses, if provided the major_code_picker will be 
+   *     campus = string, default is all campuses, if provided the major_code_picker will be
    *          restricted down to just the majors offered on that particular campus.
    */
   public function asu_rfi_form( $atts, $content = '' ) {
-    ensure_default($atts, 'campus', null);
-    ensure_default($atts, 'major_code', null);
+    ensure_default( $atts, 'campus', null );
+    ensure_default( $atts, 'major_code', null );
 
     $view_data = array(
           'form_endpoint' => self::DEVELOPMENT_FORM_ENDPOINT,
@@ -155,18 +155,18 @@ class ASU_RFI_Form_Shortcodes extends Hook {
     }
 
     if ( isset( $atts['college_program_code'] ) ) {
-      $atts['college_program_code'] = add_degree_level_prefix( 
-        $view_data['college_program_code'], 
-        $view_data['degreeLevel']);
-      
+      $atts['college_program_code'] = add_degree_level_prefix(
+          $view_data['college_program_code'],
+      $view_data['degreeLevel']);
+
       $view_data['college_program_code'] = $atts['college_program_code'];
 
       if ( isset( $atts['major_code_picker'] ) ) {
         $service = new Services\ASUDegreeService();
-        $view_data['major_codes'] = $service->get_majors_per_college( 
-          $atts['college_program_code'], 
-          $view_data['degreeLevel'], 
-          $campus );
+        $view_data['major_codes'] = $service->get_majors_per_college(
+            $atts['college_program_code'],
+            $view_data['degreeLevel'],
+        $campus );
       }
     }
 

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -1,8 +1,10 @@
 <?php
 namespace ASURFIWordPress\Shortcodes;
 use Honeycomb\Wordpress\Hook;
-use ASURFIWordPress\Services as Services;
-use ASURFIWordPress\Admin as Admin;
+use ASURFIWordPress\Services\ASUDegreeService;
+use ASURFIWordPress\Services\StudentTypeService;
+use ASURFIWordPress\Services\ASUCollegeService;
+use ASURFIWordPress\Admin\ASU_RFI_Admin_Page;
 use ASURFIWordPress\Helpers\ConditionalHelper;
 
 
@@ -118,8 +120,8 @@ class ASU_RFI_Form_Shortcodes extends Hook {
     ensure_default( $atts, 'major_code', null );
     ensure_default( $atts, 'college_program_code', $this->get_option_attribute_or_default(
         array(
-                'name'      => Admin\ASU_RFI_Admin_Page::$options_name,
-                'attribute' => Admin\ASU_RFI_Admin_Page::$college_code_option_name,
+                'name'      => ASU_RFI_Admin_Page::$options_name,
+                'attribute' => ASU_RFI_Admin_Page::$college_code_option_name,
                 'default'   => null,
     ) ) );
 
@@ -128,14 +130,14 @@ class ASU_RFI_Form_Shortcodes extends Hook {
           'redirect_back_url' => get_permalink(),
           'source_id' => $this->get_option_attribute_or_default(
               array(
-                'name'      => Admin\ASU_RFI_Admin_Page::$options_name,
-                'attribute' => Admin\ASU_RFI_Admin_Page::$source_id_option_name,
+                'name'      => ASU_RFI_Admin_Page::$options_name,
+                'attribute' => ASU_RFI_Admin_Page::$source_id_option_name,
                 'default'   => 0,
               )
           ),
           'degreeLevel' => 'ugrad', // default to undergrad
-          'enrollment_terms' => Services\ASUDegreeService::get_available_enrollment_terms(),
-          'student_types' => Services\StudentTypeService::get_student_types(),
+          'enrollment_terms' => ASUDegreeService::get_available_enrollment_terms(),
+          'student_types' => StudentTypeService::get_student_types(),
           'college_program_code' => null,
           'major_code_picker' => false,
           'major_code' => $atts['major_code'],
@@ -155,27 +157,28 @@ class ASU_RFI_Form_Shortcodes extends Hook {
     // Use the attribute source id over the sites option
     if ( isset( $atts['degree_level'] ) && ConditionalHelper::graduate( $atts['degree_level'] ) ) {
       $view_data['degreeLevel'] = 'grad';
-      $view_data['student_types'] = Services\StudentTypeService::get_student_types( 'grad' );
+      $view_data['student_types'] = StudentTypeService::get_student_types( 'grad' );
     } elseif ( isset( $atts['degree_level'] ) && ConditionalHelper::undergraduate( $atts['degree_level'] ) ) {
       $view_data['degreeLevel'] = 'ugrad';
-      $view_data['student_types'] = Services\StudentTypeService::get_student_types( 'undergrad' );
+      $view_data['student_types'] = StudentTypeService::get_student_types( 'undergrad' );
     }
 
     // get the Majors offered for this college, degree level and/or campus
     if ( isset( $atts['college_program_code'] ) ) {
 
-      $atts['college_program_code'] = Services\ASUCollegeService::add_degree_level_prefix(
+      $atts['college_program_code'] = ASUCollegeService::add_degree_level_prefix(
           $atts['college_program_code'],
       $view_data['degreeLevel']);
 
       $view_data['college_program_code'] = $atts['college_program_code'];
 
       if ( isset( $atts['major_code_picker'] ) ) {
-        $service = new Services\ASUDegreeService();
+        $service = new ASUDegreeService();
         $view_data['major_codes'] = $service->get_majors_per_college(
             $atts['college_program_code'],
             $view_data['degreeLevel'],
-        $campus );
+            $campus
+          );
       }
     }
 

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -105,10 +105,10 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    *     degree_level = 'ugrad' or 'grad' Default is 'ugrad'
    *     test_mode = 'test' or leave blank for the default production
    *     source_id = integer site identifier (issued by Enrollment services department) will default to site wide setting
-   *     college_program_code = 4 character string, usually all caps, like 
-   *         "GRLA" for College of Liberal Arts and Sciences or "GRSU" for "School of Sustainability"  
+   *     college_program_code = 4 character string, usually all caps, like
+   *         "GRLA" for College of Liberal Arts and Sciences or "GRSU" for "School of Sustainability"
    *     major_code_picker = boolean, if true then programs for the college will be provided in a dropdown
-   *     major_code = string, if provided then no picker, just a hidden major code value 
+   *     major_code = string, if provided then no picker, just a hidden major code value
    */
   public function asu_rfi_form( $atts, $content = '' ) {
 
@@ -141,24 +141,24 @@ class ASU_RFI_Form_Shortcodes extends Hook {
     }
 
     // Use the attribute source id over the sites option
-    if ( isset( $atts['degree_level'] ) && ConditionalHelper::graduate( $atts['degree_level']) ) {
+    if ( isset( $atts['degree_level'] ) && ConditionalHelper::graduate( $atts['degree_level'] ) ) {
       $view_data['degreeLevel'] = 'grad';
-      $view_data['student_types'] = Services\StudentTypeService::get_student_types('grad');
-    } else if ( isset( $atts['degree_level'] ) && ConditionalHelper::undergraduate( $atts['degree_level']) ) {
+      $view_data['student_types'] = Services\StudentTypeService::get_student_types( 'grad' );
+    } elseif ( isset( $atts['degree_level'] ) && ConditionalHelper::undergraduate( $atts['degree_level'] ) ) {
       $view_data['degreeLevel'] = 'ugrad';
-      $view_data['student_types'] = Services\StudentTypeService::get_student_types('undergrad');
+      $view_data['student_types'] = Services\StudentTypeService::get_student_types( 'undergrad' );
     }
 
-    if( isset( $atts['college_program_code'] ) ) {
+    if ( isset( $atts['college_program_code'] ) ) {
       $view_data['college_program_code'] = $atts['college_program_code'];
 
-      if( isset( $atts['major_code_picker'] ) ) {
+      if ( isset( $atts['major_code_picker'] ) ) {
         $service = new Services\ASUDegreeService();
-        $view_data['major_codes'] = $service->get_majors_per_college( $atts['college_program_code'], $view_data['degreeLevel']);
+        $view_data['major_codes'] = $service->get_majors_per_college( $atts['college_program_code'], $view_data['degreeLevel'] );
       }
     }
 
-    if( isset( $atts['major_code'])) {
+    if ( isset( $atts['major_code'] ) ) {
       $view_data['major_code'] = $atts['major_code'];
     }
 

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -106,7 +106,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    *     test_mode = 'test' or leave blank for the default production
    *     source_id = integer site identifier (issued by Enrollment services department) will default to site wide setting
    *     college_program_code = 2-5 character string, usually all caps, like
-   *         "LA" for College of Liberal Arts and Sciences or "SU" for "School of Sustainability". 
+   *         "LA" for College of Liberal Arts and Sciences or "SU" for "School of Sustainability".
    *         Will default to the value set in the RFI Admin Options menu.
    *     major_code_picker = boolean, if true then programs for the college will be provided in a dropdown
    *     major_code = string, if provided then no picker, just a hidden major code value
@@ -117,16 +117,16 @@ class ASU_RFI_Form_Shortcodes extends Hook {
     ensure_default( $atts, 'campus', null );
     ensure_default( $atts, 'major_code', null );
     ensure_default( $atts, 'college_program_code', $this->get_option_attribute_or_default(
-              array(
+        array(
                 'name'      => Admin\ASU_RFI_Admin_Page::$options_name,
                 'attribute' => Admin\ASU_RFI_Admin_Page::$college_code_option_name,
                 'default'   => null,
-              ) ) );
+    ) ) );
 
     $view_data = array(
           'form_endpoint' => self::DEVELOPMENT_FORM_ENDPOINT,
           'redirect_back_url' => get_permalink(),
-          'source_id' =>  $this->get_option_attribute_or_default(
+          'source_id' => $this->get_option_attribute_or_default(
               array(
                 'name'      => Admin\ASU_RFI_Admin_Page::$options_name,
                 'attribute' => Admin\ASU_RFI_Admin_Page::$source_id_option_name,
@@ -161,12 +161,12 @@ class ASU_RFI_Form_Shortcodes extends Hook {
       $view_data['student_types'] = Services\StudentTypeService::get_student_types( 'undergrad' );
     }
 
-    // get the Majors offered for this college, degree level and/or campus 
+    // get the Majors offered for this college, degree level and/or campus
     if ( isset( $atts['college_program_code'] ) ) {
 
       $atts['college_program_code'] = Services\ASUCollegeService::add_degree_level_prefix(
           $atts['college_program_code'],
-          $view_data['degreeLevel']);
+      $view_data['degreeLevel']);
 
       $view_data['college_program_code'] = $atts['college_program_code'];
 
@@ -175,7 +175,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
         $view_data['major_codes'] = $service->get_majors_per_college(
             $atts['college_program_code'],
             $view_data['degreeLevel'],
-            $campus );
+        $campus );
       }
     }
 

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -128,7 +128,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
           'student_types' => Services\StudentTypeService::get_student_types(),
           'college_program_code' => null,
           'major_code_picker' => false,
-          // 'major_code' => null,
+          'major_code' => null,
         );
 
     if ( isset( $atts['test_mode'] ) && 0 === strcasecmp( 'test', $atts['test_mode'] ) ) {
@@ -151,11 +151,15 @@ class ASU_RFI_Form_Shortcodes extends Hook {
 
     if( isset( $atts['college_program_code'] ) ) {
       $view_data['college_program_code'] = $atts['college_program_code'];
+
+      if( isset( $atts['major_code_picker'] ) ) {
+        $service = new Services\ASUDegreeService();
+        $view_data['major_codes'] = $service->get_majors_per_college($atts['college_program_code']);
+      }
     }
 
-    if( isset( $atts['major_code_picker']) && 0 === strcasecmp( 'true', $atts['major_code_picker'])) {
-      $service = new Services\ASUDegreeService();
-      $view_data['major_codes'] = $service->get_majors_per_college($atts['college_program_code']);
+    if( isset( $atts['major_code'])) {
+      $view_data['major_code'] = $atts['major_code'];
     }
 
     $view_data = $this->look_for_a_submission_response( $view_data );

--- a/src/stores/asu-degree-store.php
+++ b/src/stores/asu-degree-store.php
@@ -20,13 +20,12 @@ class ASUDegreeStore {
   public static $transient_TTL = DAY_IN_SECONDS * 30;
 
   public static function get_programs( $college, $degree_level = 'graduate', $campus = null ) {
-    $transient_name = ASUDegreeStore::get_transient_name($college, $degree_level, $campus);
+    $transient_name = ASUDegreeStore::get_transient_name( $college, $degree_level, $campus );
     if ( WP_DEBUG or false === ( $transient_content = get_transient( $transient_name ) ) ) {
       // transient doesn't exist, so regenerate the data and save the transient for next time
       try {
         $degree_service = new ASUDegreeService();
         $transient_content = $degree_service->get_majors_per_college( $college, $degree_level, $campus );
-        print_r($transient_content);
         set_transient( $transient_name, $transient_content, ASUDegreeStore::$transient_TTL );
       } catch (Exception $e) {
         // don't store an error in the transient
@@ -46,11 +45,11 @@ class ASUDegreeStore {
     } else {
       $degree_level = 'ugrad';
     }
-    
+
     if ( ConditionalHelper::online( $campus ) ) {
       $campus = 'ONLNE';
-    } else if ( empty( $campus ) ) {
-      $campus =  '';
+    } elseif ( empty( $campus ) ) {
+      $campus = '';
     } else {
       $campus = strtoupper( $campus );
     }
@@ -58,9 +57,9 @@ class ASUDegreeStore {
     $college = strtoupper( $college );
 
     // use md5 so we dont run into any length issues, md5 always returns 32 characters
-    $hashed_parameters = md5( $college.' '.$degree_level.' '.$campus );
+    $hashed_parameters = md5( $college . ' ' . $degree_level . ' ' . $campus );
 
-    return 'ASURFI'.$hashed_parameters;
+    return 'ASURFI' . $hashed_parameters;
   }
 
 

--- a/src/stores/asu-degree-store.php
+++ b/src/stores/asu-degree-store.php
@@ -17,16 +17,16 @@ if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
  * XML RPC API Docs: http://www.public.asu.edu/~lcabre/javadocs/dsws/
  */
 class ASUDegreeStore {
-  public static $transient_TTL = DAY_IN_SECONDS * 30;
 
   public static function get_programs( $college, $degree_level = 'graduate', $campus = null ) {
+    $transient_TTL = DAY_IN_SECONDS * 30;
     $transient_name = ASUDegreeStore::get_transient_name( $college, $degree_level, $campus );
     if ( WP_DEBUG or false === ( $transient_content = get_transient( $transient_name ) ) ) {
       // transient doesn't exist, so regenerate the data and save the transient for next time
       try {
         $degree_service = new ASUDegreeService();
         $transient_content = $degree_service->get_majors_per_college( $college, $degree_level, $campus );
-        set_transient( $transient_name, $transient_content, ASUDegreeStore::$transient_TTL );
+        set_transient( $transient_name, $transient_content, $transient_TTL );
       } catch (Exception $e) {
         // don't store an error in the transient
         error_log( $e->getMessage() );

--- a/src/stores/asu-degree-store.php
+++ b/src/stores/asu-degree-store.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace ASURFIWordPress\Stores;
+
+use ASURFIWordPress\Helpers\ConditionalHelper;
+use ASURFIWordPress\Services\ASUDegreeService;
+
+// Avoid direct calls to this file
+if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
+  header( 'Status: 403 Forbidden' );
+  header( 'HTTP/1.1 403 Forbidden' );
+  exit();
+}
+
+/** ASU Degree Store
+ * Providing a caching data store for the ASU Degrees Service
+ * XML RPC API Docs: http://www.public.asu.edu/~lcabre/javadocs/dsws/
+ */
+class ASUDegreeStore {
+  public static $transient_TTL = DAY_IN_SECONDS * 30;
+
+  public static function get_programs( $college, $degree_level = 'graduate', $campus = null ) {
+    $transient_name = ASUDegreeStore::get_transient_name($college, $degree_level, $campus);
+    if ( WP_DEBUG or false === ( $transient_content = get_transient( $transient_name ) ) ) {
+      // transient doesn't exist, so regenerate the data and save the transient for next time
+      try {
+        $degree_service = new ASUDegreeService();
+        $transient_content = $degree_service->get_majors_per_college( $college, $degree_level, $campus );
+        print_r($transient_content);
+        set_transient( $transient_name, $transient_content, ASUDegreeStore::$transient_TTL );
+      } catch (Exception $e) {
+        // don't store an error in the transient
+        error_log( $e->getMessage() );
+      }
+    }
+    return $transient_content;
+  }
+
+  /** Get a unique encoded transient string given these three parameters.
+   * Note: transient names shouldn't be longer than 40 characters
+   */
+  public static function get_transient_name( $college, $degree_level, $campus ) {
+    // Need to coaurse variable spellings into one so we dont store duplicate transients.
+    if ( ConditionalHelper::graduate( $degree_level ) ) {
+      $degree_level = 'grad';
+    } else {
+      $degree_level = 'ugrad';
+    }
+    
+    if ( ConditionalHelper::online( $campus ) ) {
+      $campus = 'ONLNE';
+    } else if ( empty( $campus ) ) {
+      $campus =  '';
+    } else {
+      $campus = strtoupper( $campus );
+    }
+
+    $college = strtoupper( $college );
+
+    // use md5 so we dont run into any length issues, md5 always returns 32 characters
+    $hashed_parameters = md5( $college.' '.$degree_level.' '.$campus );
+
+    return 'ASURFI'.$hashed_parameters;
+  }
+
+
+}

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -50,7 +50,7 @@
         </div>
       </div>
       <div class="form-group optional has-feedback">
-        <label class="control-label col-sm-3" for="StudentType">I am going to be a</label>
+        <label class="control-label col-sm-3" for="StudentType">I will be a future</label>
         <div class="col-sm-9">
           <select name="StudentType" id="StudentType" class="form-select">
             <option value="" selected="selected">-</option>

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -68,7 +68,7 @@
       {{#if major_code }}
         <input type="hidden" name="poiCode" value="{{ major_code }}">
       {{/if}}
-
+      
       {{#if major_codes }}
         <div class="form-group optional has-feedback">
           <label class="control-label col-sm-3" for="poiCode">Major</label>

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -69,13 +69,13 @@
         <input type="hidden" name="poiCode" value="{{ major_code }}">
       {{/if}}
 
-      {{#if major_code_options }}
+      {{#if major_codes }}
         <div class="form-group optional has-feedback">
           <label class="control-label col-sm-3" for="poiCode">Major</label>
           <div class="col-sm-9">
             <select name="poiCode" id="poiCode" class="form-select">
               <option value="" selected="selected">-</option>
-              {{#each major_code_options }}
+              {{#each major_codes }}
                 <option value="{{ value }}">{{ label }}</option>
               {{/each}}
             </select>

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -61,7 +61,10 @@
         </div>
       </div>
       
-      
+      {{#if college_program_code }}
+        <input type="hidden" name="collegeOfInterest" value="{{ college_program_code }}">
+      {{/if}}
+
       <div class="form-group">
         <div class="col-sm-3"></div>
         <div class="col-sm-9">

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -65,6 +65,24 @@
         <input type="hidden" name="collegeOfInterest" value="{{ college_program_code }}">
       {{/if}}
 
+      {{#if major_code }}
+        <input type="hidden" name="poiCode" value="{{ major_code }}">
+      {{/if}}
+
+      {{#if major_code_options }}
+        <div class="form-group optional has-feedback">
+          <label class="control-label col-sm-3" for="poiCode">Major</label>
+          <div class="col-sm-9">
+            <select name="poiCode" id="poiCode" class="form-select">
+              <option value="" selected="selected">-</option>
+              {{#each major_code_options }}
+                <option value="{{ value }}">{{ label }}</option>
+              {{/each}}
+            </select>
+          </div>
+        </div>
+      {{/if}}
+
       <div class="form-group">
         <div class="col-sm-3"></div>
         <div class="col-sm-9">

--- a/tests/unit/test-address-service.php
+++ b/tests/unit/test-address-service.php
@@ -9,6 +9,8 @@ use ASURFIWordPress\Services\AddressService;
 
 /**
  * Address Service test cases
+ * @group services
+ * @group address-service
  */
 class AddressTestService extends WP_UnitTestCase {
 

--- a/tests/unit/test-asu-degree-service.php
+++ b/tests/unit/test-asu-degree-service.php
@@ -14,11 +14,6 @@ use ASURFIWordPress\Services\ASUDegreeService;
  */
 class ASUDegreeServiceTest extends WP_UnitTestCase {
 
-  function test_get_available_enrollment_terms() {
-    $terms = ASUDegreeService::get_available_enrollment_terms();
-    $this->assertInternalType('array', $terms);
-    $this->assertGreaterThan(4, count($terms), 'there should be more than 4 terms');    
-  }
 
   function test_get_programs_per_campus() {
     $service = new ASUDegreeService();

--- a/tests/unit/test-asu-degree-service.php
+++ b/tests/unit/test-asu-degree-service.php
@@ -26,8 +26,28 @@ class ASUDegreeServiceTest extends WP_UnitTestCase {
 
   function test_get_programs_per_campus() {
     $service = new ASUDegreeService();
-    $programs = $service->get_programs_per_campus('TEMPE');
+    $programs = $service->get_programs_per_campus();
     $this->assertInternalType('array', $programs);
-    $this->assertGreaterThan(4, count($programs), 'there should be more than 4 programs');  
+    $this->assertGreaterThan(4, count($programs), 'there should be more than 4 programs');
+  }
+  function test_get_programs_per_campus_undergrad() {
+    $service = new ASUDegreeService();
+    $programs = $service->get_programs_per_campus('undergraduate');
+    $this->assertInternalType('array', $programs);
+    $this->assertGreaterThan(4, count($programs), 'there should be more than 4 programs');
+  }
+
+  function test_get_majors_per_college() {
+    $service = new ASUDegreeService();
+    $majors = $service->get_majors_per_college('GRSU', 'graduate');
+    $this->assertInternalType('array', $majors);
+    $this->assertGreaterThan(4, count($majors), 'there should be more than 4 majors');
+  }
+
+  function test_get_majors_per_college_undergrad() {
+    $service = new ASUDegreeService();
+    $majors = $service->get_majors_per_college('UGSU', 'undergraduate');
+    $this->assertInternalType('array', $majors);
+    $this->assertGreaterThan(1, count($majors), 'there should be more than 1 majors');
   }
 }

--- a/tests/unit/test-asu-degree-service.php
+++ b/tests/unit/test-asu-degree-service.php
@@ -3,11 +3,14 @@
  * Class ASUDegreeServiceTest
  *
  * @package Asu_Rfi_Wordpress_Plugin
+
  */
 use ASURFIWordPress\Services\ASUDegreeService;
 
 /**
  * ASUDegreeService test case.
+ * @group services 
+ * @group asu-degree-service
  */
 class ASUDegreeServiceTest extends WP_UnitTestCase {
 
@@ -43,4 +46,12 @@ class ASUDegreeServiceTest extends WP_UnitTestCase {
     $this->assertInternalType('array', $majors);
     $this->assertGreaterThan(1, count($majors), 'there should be more than 1 majors');
   }
+
+  function test_get_programs_per_multiple_campuses() {
+    $service = new ASUDegreeService();
+    $programs = $service->get_programs_on_all_campuses('undergraduate');
+    $this->assertInternalType('array', $programs);
+    $this->assertGreaterThan(4, count($programs), 'there should be more than 4 programs');
+  }
+
 }

--- a/tests/unit/test-asu-degree-service.php
+++ b/tests/unit/test-asu-degree-service.php
@@ -23,4 +23,11 @@ class ASUDegreeServiceTest extends WP_UnitTestCase {
     $this->assertInternalType('array', $colleges);
     $this->assertGreaterThan(4, count($colleges), 'there should be more than 4 colleges');  
   }
+
+  function test_get_programs_per_campus() {
+    $service = new ASUDegreeService();
+    $programs = $service->get_programs_per_campus('TEMPE');
+    $this->assertInternalType('array', $programs);
+    $this->assertGreaterThan(4, count($programs), 'there should be more than 4 programs');  
+  }
 }

--- a/tests/unit/test-asu-degree-service.php
+++ b/tests/unit/test-asu-degree-service.php
@@ -17,13 +17,6 @@ class ASUDegreeServiceTest extends WP_UnitTestCase {
     $this->assertGreaterThan(4, count($terms), 'there should be more than 4 terms');    
   }
 
-  function test_get_colleges() {
-    $service = new ASUDegreeService();
-    $colleges = $service->get_colleges();
-    $this->assertInternalType('array', $colleges);
-    $this->assertGreaterThan(4, count($colleges), 'there should be more than 4 colleges');  
-  }
-
   function test_get_programs_per_campus() {
     $service = new ASUDegreeService();
     $programs = $service->get_programs_per_campus();

--- a/tests/unit/test-asu-degree-store.php
+++ b/tests/unit/test-asu-degree-store.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Class ASUDegreeStoreTest
+ *
+ * @package Asu_Rfi_Wordpress_Plugin
+
+ */
+use ASURFIWordPress\Stores\ASUDegreeStore;
+
+/**
+ * ASUDegreeStore test case.
+ * @group stores 
+ * @group asu-degree-store
+ */
+class ASUDegreeStoreTest extends WP_UnitTestCase {
+
+  function test_get_transient_name_returns_a_string() {
+    $name = ASUDegreeStore::get_transient_name('abc','undergrad','hij');
+    $this->assertInternalType('string', $name);
+  }
+
+  function test_get_transient_name_returns_a_unique_string_thats_case_insensitive() {
+    $first = ASUDegreeStore::get_transient_name('abc','undergrad','hij');
+    $second = ASUDegreeStore::get_transient_name('ABC','undergrad','hij');
+    $this->assertEquals($first, $second);
+  }
+
+    function test_get_transient_name_returns_a_unique_string_given_different_inputs() {
+    $first = ASUDegreeStore::get_transient_name('foo','undergrad','hij');
+    $second = ASUDegreeStore::get_transient_name('bar','undergrad','hij');
+    $this->assertNotEquals($first, $second);
+  }
+
+  function test_get_transient_name_length() {
+    $name = ASUDegreeStore::get_transient_name('AREALLYREALLYREALLYREALLYLONGCOLLEGENAME','undergraduate','AREALLYLONGCAMPUSNAME');
+    $this->assertLessThan(40, count($name), 'transient names should be less that 40 characters');
+  }
+
+  function test_get_programs() {
+    // todo: mock the ASUDegreeService response
+    $programs = ASUDegreeStore::get_programs('GRSU', 'graduate', NULL);
+    $this->assertInternalType('array', $programs);
+    $this->assertGreaterThan(4, count($programs));
+  }
+
+  // todo: test that the transeient actually gets stored and reused 
+
+}

--- a/tests/unit/test-asu-semester-service.php
+++ b/tests/unit/test-asu-semester-service.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Class ASUSemesterServiceTest
+ *
+ * @package Asu_Rfi_Wordpress_Plugin
+
+ */
+use ASURFIWordPress\Services\ASUSemesterService;
+
+/**
+ * ASUSemesterService test case.
+ * @group services 
+ * @group asu-semester-service
+ */
+class ASUSemesterServiceTest extends WP_UnitTestCase {
+
+  function test_get_available_enrollment_terms() {
+    $terms = ASUSemesterService::get_available_enrollment_terms();
+    $this->assertInternalType('array', $terms);
+    $this->assertGreaterThan(4, count($terms), 'there should be more than 4 terms');    
+  }
+
+}

--- a/tests/unit/test-college-service.php
+++ b/tests/unit/test-college-service.php
@@ -37,4 +37,9 @@ class ASUCollegeServiceTest extends WP_UnitTestCase {
     $this->assertEquals('UGUGABC', $redundantabcundergraduate);
   }
 
+  function test_degree_level_prefixer_null_case() {
+    $abcgraduate = ASUCollegeService::add_degree_level_prefix('', 'graduate');
+    $this->assertEquals('', $abcgraduate);
+  }
+
 }

--- a/tests/unit/test-college-service.php
+++ b/tests/unit/test-college-service.php
@@ -3,11 +3,14 @@
  * Class ASUCollegeServiceTest
  *
  * @package Asu_Rfi_Wordpress_Plugin
+
  */
 use ASURFIWordPress\Services\ASUCollegeService;
 
 /**
  * ASUCollegeService test case.
+ * @group services 
+ * @group asu-college-service
  */
 class ASUCollegeServiceTest extends WP_UnitTestCase {
 

--- a/tests/unit/test-college-service.php
+++ b/tests/unit/test-college-service.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Class ASUCollegeServiceTest
+ *
+ * @package Asu_Rfi_Wordpress_Plugin
+ */
+use ASURFIWordPress\Services\ASUCollegeService;
+
+/**
+ * ASUCollegeService test case.
+ */
+class ASUCollegeServiceTest extends WP_UnitTestCase {
+
+  function test_get_colleges() {
+    $service = new ASUCollegeService();
+    $colleges = $service->get_colleges();
+    $this->assertInternalType('array', $colleges);
+    $this->assertGreaterThan(4, count($colleges), 'there should be more than 4 colleges');  
+  }
+
+  function test_get_college_code() {
+    $service = new ASUCollegeService();
+    $code = $service->get_college_code('Sustainability, School of');
+    $this->assertInternalType('string', $code);
+    $this->assertEquals('CSS', $code);
+  }
+
+}

--- a/tests/unit/test-college-service.php
+++ b/tests/unit/test-college-service.php
@@ -28,4 +28,13 @@ class ASUCollegeServiceTest extends WP_UnitTestCase {
     $this->assertEquals('CSS', $code);
   }
 
+  function test_degree_level_prefixer() {
+    $abcgraduate = ASUCollegeService::add_degree_level_prefix('ABC', 'graduate');
+    $this->assertEquals('GRABC', $abcgraduate);
+    $abcundergraduate = ASUCollegeService::add_degree_level_prefix('UGABC', 'undergraduate');
+    $this->assertEquals('UGABC', $abcundergraduate);
+    $redundantabcundergraduate = ASUCollegeService::add_degree_level_prefix('UGUGABC', 'undergraduate');
+    $this->assertEquals('UGUGABC', $redundantabcundergraduate);
+  }
+
 }

--- a/tests/unit/test-conditional-helpers.php
+++ b/tests/unit/test-conditional-helpers.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Class ConditionalHelperTest
+ *
+ * @package Asu_Rfi_Wordpress_Plugin
+ */
+use ASURFIWordPress\Helpers\ConditionalHelper;
+
+/**
+ * ConditionalHelper test case.
+ * @group helpers
+ */
+class ConditionalHelperTest extends WP_UnitTestCase {
+
+  function test_grad_helper() {
+    $this->assertTrue(ConditionalHelper::graduate('grad'));
+    $this->assertTrue(ConditionalHelper::graduate('Graduate'));
+    $this->assertFalse(ConditionalHelper::graduate('foo'));
+  }
+
+  function test_under_grad_helper() {
+    $this->assertTrue(ConditionalHelper::undergraduate('uGrad'));
+    $this->assertTrue(ConditionalHelper::undergraduate('UNDERgraduate'));
+    $this->assertTrue(ConditionalHelper::undergraduate('undergrad'));
+    $this->assertFalse(ConditionalHelper::undergraduate('foo'));
+  }
+
+}

--- a/tests/unit/test-conditional-helpers.php
+++ b/tests/unit/test-conditional-helpers.php
@@ -8,7 +8,8 @@ use ASURFIWordPress\Helpers\ConditionalHelper;
 
 /**
  * ConditionalHelper test case.
- * @group helpers
+ * @group helpers 
+ * @group conditional-helpers
  */
 class ConditionalHelperTest extends WP_UnitTestCase {
 

--- a/tests/unit/test-conditional-helpers.php
+++ b/tests/unit/test-conditional-helpers.php
@@ -25,4 +25,10 @@ class ConditionalHelperTest extends WP_UnitTestCase {
     $this->assertFalse(ConditionalHelper::undergraduate('foo'));
   }
 
+  function test_online_helper() {
+    $this->assertTrue(ConditionalHelper::online('online'));
+    $this->assertTrue(ConditionalHelper::online('onlne'));
+    $this->assertTrue(ConditionalHelper::online('on-line'));
+    $this->assertFalse(ConditionalHelper::online('twoline'));
+  }
 }

--- a/tests/unit/test-shortcodes.php
+++ b/tests/unit/test-shortcodes.php
@@ -7,6 +7,7 @@
 
 /**
  * Shortcodes test case.
+ * @group shortcodes
  */
 class ShortCodesTest extends WP_UnitTestCase {
 
@@ -49,5 +50,15 @@ class ShortCodesTest extends WP_UnitTestCase {
     $this->assertContains('"abcd"', $result);
   }
 
+  function test_shortcode_major_code() {
+    $result = do_shortcode( '[asu-rfi-form major_code="abcd"]' );
+    $this->assertContains('"abcd"', $result);
+  }
+
+  // TODO: need to mock services
+  // function test_shortcode_major_picker() {
+  //   $result = do_shortcode( '[asu-rfi-form major_code_picker=true]' );
+  //   $this->assertContains('<select name="poiCode"', $result);
+  // }
 
 }

--- a/tests/unit/test-shortcodes.php
+++ b/tests/unit/test-shortcodes.php
@@ -46,19 +46,19 @@ class ShortCodesTest extends WP_UnitTestCase {
   }
 
   function test_shortcode_college_code() {
-    $result = do_shortcode( '[asu-rfi-form college_program_code="abcd"]' );
-    $this->assertContains('"abcd"', $result);
+    $result = do_shortcode( '[asu-rfi-form college_program_code="ABCD"]' );
+    $this->assertContains('ABCD"', $result); // Note: the program code gets the GR or UG appended to it
   }
 
   function test_shortcode_major_code() {
-    $result = do_shortcode( '[asu-rfi-form major_code="abcd"]' );
-    $this->assertContains('"abcd"', $result);
+    $result = do_shortcode( '[asu-rfi-form major_code="ABCD"]' );
+    $this->assertContains('"ABCD"', $result);
   }
 
   // TODO: need to mock services
-  // function test_shortcode_major_picker() {
-  //   $result = do_shortcode( '[asu-rfi-form major_code_picker=true]' );
-  //   $this->assertContains('<select name="poiCode"', $result);
-  // }
+  function test_shortcode_major_picker() {
+    $result = do_shortcode( '[asu-rfi-form major_code_picker=true college_program_code="SU"]' );
+    $this->assertContains('<select name="poiCode"', $result);
+  }
 
 }

--- a/tests/unit/test-shortcodes.php
+++ b/tests/unit/test-shortcodes.php
@@ -44,4 +44,10 @@ class ShortCodesTest extends WP_UnitTestCase {
     $this->assertContains('name="testmode" value="Test"', $result);
   }
 
+  function test_shortcode_college_code() {
+    $result = do_shortcode( '[asu-rfi-form college_program_code="abcd"]' );
+    $this->assertContains('"abcd"', $result);
+  }
+
+
 }


### PR DESCRIPTION
Requires school codes, further calls to the ASU Degree XML RPC services to get available degrees. 
Maintaining backwards compatibility with previous short code attributes. 

* Added new site config setting: **College Program Code**
* reworded student type to match other colleges phrase of 'I will be a future' 
* new short code attributes for `[asu-rfi-form]`
  * college_program_code
  * major_code_picker
  * major_code
  * campus
* Calls to ASU's XML RPC server are cached with a 30 day Time To Live.

New form look: 
<img width="502" alt="screen shot 2017-01-30 at 4 55 33 pm" src="https://cloud.githubusercontent.com/assets/295804/22447084/86dfca7e-e70d-11e6-862f-3373b29064e4.png">

