### PR TITLE
Auto-hide `studentType` when POI code is pre-selected in shortcode

### DIFF
--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -190,6 +190,22 @@ class ASU_RFI_Form_Shortcodes extends Hook {
             $view_data['degreeLevel'],
             $atts['campus']
         );
+
+      } elseif ( 'grad' === $view_data['degreeLevel'] && ! empty( $atts['major_code'] ) ) {
+        // since 'major code picker' is not used, if this is for a Graduate form
+        // assign studentType to match the degree program (Masters, Doctoral, etc.)
+        $programs = ASUDegreeStore::get_programs(
+            $atts['college_program_code'],
+            $view_data['degreeLevel'],
+            $atts['campus']
+        );
+        // find major code in college's available degrees
+        foreach ( $programs as $program ) {
+          if ( $program['value'] ===  $atts['major_code'] ) {
+            $view_data['student_type'] = $program['type'];
+            break;
+          }
+        }
       }
     }
 

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -54,6 +54,9 @@
   {{#if major_code }}
     <input type="hidden" name="poiCode" value="{{ major_code }}">
   {{/if}}
+  {{#if student_type }}
+    <input type="hidden" name="StudentType" value="{{ student_type }}">
+  {{/if}}
 
   {{#if major_codes }}
     <div class="form-group required has-feedback">
@@ -67,16 +70,18 @@
     </div>
   {{/if}}
 
-  {{#if_cond degreeLevel '==' 'grad'}} {{! Move the StudentType field after POICode because StudentType will be auto-selected !}}
-    <div class="form-group required has-feedback">
-      <label class="control-label" for="StudentType">I will be a future</label>
-      <select name="StudentType" id="StudentType" class="form-control" required aria-required="true">
-        <option value="" selected="selected">-</option>
-        {{#each student_types }}
-          <option value="{{ value }}">{{ label }}</option>
-        {{/each}}
-      </select>
-    </div>
+  {{#if_cond degreeLevel '==' 'grad'}} {{! On grad forms, move the StudentType field after POICode because StudentType will be auto-selected }}
+    {{#unless student_type }} {{! If shortcode hasn't pre-selected the studentType, render dropdown }}
+      <div class="form-group required has-feedback">
+        <label class="control-label" for="StudentType">I will be a future</label>
+        <select name="StudentType" id="StudentType" class="form-control" required aria-required="true">
+          <option value="" selected="selected">-</option>
+          {{#each student_types }}
+            <option value="{{ value }}">{{ label }}</option>
+          {{/each}}
+        </select>
+      </div>
+    {{/unless}}
   {{/if_cond}}
 
   {{#if enrollment_terms }}


### PR DESCRIPTION
When the grad form shortcode has preselected the POI code, the studentType field needs to be also pre-filled automatically and the dropdown hidden.