### PR TITLE
Add shortcode parameter for permitted semesters in start term dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ WordPress plugin to submit Request For Information requests into Salesforce
   * **source_id** = integer site identifier (issued by Enrollment services department) will default to the site wide setting configured in the plugin admin settings.
   * **college_program_code** = 2-5 character string, usually all caps, eg `LA` for `College of Liberal Arts and Sciences` or `SU` for `School of Sustainability`, it will default to the value set in the RFI Admin Options menu so only use this attribute if you want to override one specific form.
   * **campus** = eg `TEMPE` or leave blank for all Campuses.
+  * **semesters** = comma-delimited list of semesters allowed to be selected in 'My anticipated start date' dropdown (eg: `spring,summer,fall`). If omitted, the dropdown will be auto-filled with Spring, Summer, Fall for Undergrad Forms, and Spring, Fall for Grad Forms.
 
 
 ![Screenshot](http://i.imgur.com/PFWa83O.png)

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -116,7 +116,9 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    *     major_code_picker = boolean, if true then programs for the college will be provided in a dropdown
    *     major_code = string, if provided then no picker, just a hidden major code value
    *     campus = string, default is all campuses, if provided the major_code_picker will be
-   *          restricted down to just the majors offered on that particular campus.
+   *         restricted down to just the majors offered on that particular campus.
+   *     semesters = comma-delimited list of semesters to which a student can apply for submission (values:
+   *         fall, spring, summer)
    */
   public function asu_rfi_form( $atts, $content = '' ) {
     // if there are no attributes passed then $atts is not an array, its a string
@@ -132,6 +134,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
                 'attribute' => ASU_RFI_Admin_Page::$college_code_option_name,
                 'default'   => null,
     ) ) );
+    ensure_default( $atts, 'semesters', null );
 
     // shortcode attributes are always passed as strings. this ensures the value is parsed as a Boolean
     // TRUE if 'true', 1, or 'on' is used (and FALSE otherwise.)
@@ -147,7 +150,7 @@ class ASU_RFI_Form_Shortcodes extends Hook {
                 'default'   => 0,
               )
           ),
-          'enrollment_terms' => ASUSemesterService::get_available_enrollment_terms( $atts['degree_level'] ),
+          'enrollment_terms' => ASUSemesterService::get_available_enrollment_terms( $atts['degree_level'], $atts['semesters'] ),
           'student_types' => StudentTypeService::get_student_types(),
           'college_program_code' => null,
           'major_code_picker' => $atts['major_code_picker'],


### PR DESCRIPTION
The 'Anticipated Start' dropdown can be overriden to only include specific semesters in the options. The list of allowed semesters are set via a shortcode parameter, `semesters`, which is a comma-delimited list: 'spring, summer, fall'.