### PR TITLE
Add reCAPTCHA and Custom Thank You Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ WordPress plugin to submit Request For Information requests into Salesforce
 * attributes:
   * **type** = `full` or leave blank for the default simple form
   * **degree_level** = `ugrad` or `grad` Default is `ugrad`, (alternative spellings `undergraduate` and `graduate` will also work)
-  * **test_mode** = `test` or leave blank for the default production mode
+  * **test_mode** = `test` or leave blank for the default production mode. **Note:** the `test_mode` attribute is used to determine which internal ASU endpoint is used. If you are actually wanting to test an RFI form, and do not want it to end up in PeopleSoft, you **must** set this attribute to the word 'test' **in all lower case** .
   * **major_code** = eg `SUSMSUS` - for hard coding a specific major for a form
   * **major_code_picker** = `true` to enable, leave off or blank to disable showing a drop down of majors based on the campus, school and degree level specified.
   * **source_id** = integer site identifier (issued by Enrollment services department) will default to the site wide setting configured in the plugin admin settings.
   * **college_program_code** = 2-5 character string, usually all caps, eg `LA` for `College of Liberal Arts and Sciences` or `SU` for `School of Sustainability`, it will default to the value set in the RFI Admin Options menu so only use this attribute if you want to override one specific form.
   * **campus** = eg `TEMPE` or leave blank for all Campuses.
   * **semesters** = comma-delimited list of semesters allowed to be selected in 'My anticipated start date' dropdown (eg: `spring,summer,fall`). If omitted, the dropdown will be auto-filled with Spring, Summer, Fall for Undergrad Forms, and Spring, Fall for Grad Forms.
+  * **thank_you_page** = A URL to which we will send the user after an RFI submission has received a passing grade from Google's reCAPTCHA system, and was successfully submitted. To redirect to a page that is already set up in Wordpress, you can use a relative URL, as in `/about/thank-you`.
 
 ### Available Major Codes for SOS
 	SUSUSTBA - Sustainability (BA)
@@ -49,3 +50,5 @@ WordPress plugin to submit Request For Information requests into Salesforce
 
 # Analytics
 If your site is using Google Analytics and has made the `ga` function available in the global scope, uppon successful submission of the form will load the ecommerce plugin and trigger the correct evaluation of the form submission based on the geographical location of the client. Currently the formula is $100 for in state, $200 for nationall, and $300 for international.
+
+Update 3/22/19: The geo-location endpoint we were using for this process is no longer available. I'm leaving the original text here for now, but I don't believe this is true any longer.

--- a/src/admin/asu-rfi-admin-page.php
+++ b/src/admin/asu-rfi-admin-page.php
@@ -1,42 +1,48 @@
 <?php
 namespace ASURFIWordPress\Admin;
+
 use Honeycomb\Wordpress\Hook;
 // use ASURFIWordPress;
 
 // Avoid direct calls to this file
-if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
-  header( 'Status: 403 Forbidden' );
-  header( 'HTTP/1.1 403 Forbidden' );
+
+if (!defined('ASU_RFI_WORDPRESS_PLUGIN_VERSION')) {
+  header('Status: 403 Forbidden');
+  header('HTTP/1.1 403 Forbidden');
   exit();
 }
 
 /** ASU_RFI_Form_Shortcodes
  * provides the shortcode [asu-rfi-form]
  */
-class ASU_RFI_Admin_Page extends Hook {
+class ASU_RFI_Admin_Page extends Hook
+{
   use \ASURFIWordPress\Options_Handler_Trait;
 
   public static $options_name = 'asu-rfi-options';
   public static $options_group = 'asu-rfi-options_group';
   public static $source_id_option_name = 'source_id';
   public static $college_code_option_name = 'college_code';
+  public static $google_recaptcha_secret_option_name = 'recaptcha_secret_key';
   public static $section_id = 'asu-rfi-section_id';
   public static $section_name = 'asu-rfi-section_name';
   public static $page_name = 'asu-rfi-admin-page';
 
- public function __construct( $version = '0.1' ) {
-    parent::__construct( $version );
+  public function __construct($version = '0.1')
+  {
+    parent::__construct($version);
 
-    $this->add_action( 'admin_menu', $this, 'admin_menu' );
-    $this->add_action( 'admin_init', $this, 'admin_init' );
+    $this->add_action('admin_menu', $this, 'admin_menu');
+    $this->add_action('admin_init', $this, 'admin_init');
 
     // Set default options
     add_option(
-        self::$options_name,
-        array(
-          self::$source_id_option_name => 0,
-          self::$college_code_option_name => null,
-        )
+      self::$options_name,
+      array(
+        self::$source_id_option_name => 0,
+        self::$college_code_option_name => null,
+        self::$google_recaptcha_secret_option_name => '',
+      )
     );
 
     $this->define_hooks();
@@ -48,163 +54,214 @@ class ASU_RFI_Admin_Page extends Hook {
    *
    * @override
    */
-  public function define_hooks() {
-    $this->add_action( 'admin_init', $this, 'admin_init' );
+  public function define_hooks()
+  {
+    $this->add_action('admin_init', $this, 'admin_init');
   }
 
   /**
    * Set up administrative fields
    */
-  public function admin_init() {
+  public function admin_init()
+  {
     register_setting(
-        self::$options_group,
-        self::$options_name,
-        array( $this, 'form_submit' )
+      self::$options_group,
+      self::$options_name,
+      array($this, 'form_submit')
     );
 
     add_settings_section(
-        self::$section_id,
-        'ASU RFI Settings',
-        array(
-          $this,
-          'print_section_info',
-        ),
-        self::$section_name
+      self::$section_id,
+      'ASU RFI Settings',
+      array(
+        $this,
+        'print_section_info',
+      ),
+      self::$section_name
     );
 
     add_settings_field(
-        self::$source_id_option_name,
-        'Site Source Identifier',
-        array(
-          $this,
-          'source_id_on_callback',
-        ), // Callback
-        self::$section_name,
-        self::$section_id
+      self::$source_id_option_name,
+      'Site Source Identifier',
+      array(
+        $this,
+        'source_id_on_callback',
+      ), // Callback
+      self::$section_name,
+      self::$section_id
     );
 
     add_settings_field(
-        self::$college_code_option_name,
-        'Default College Code',
-        array(
-          $this,
-          'college_code_on_callback',
-        ), // Callback
-        self::$section_name,
-        self::$section_id
+      self::$college_code_option_name,
+      'Default College Code',
+      array(
+        $this,
+        'college_code_on_callback',
+      ), // Callback
+      self::$section_name,
+      self::$section_id
+    );
+
+    add_settings_field(
+      self::$google_recaptcha_secret_option_name,
+      'reCAPTCHA Secret Key',
+      array(
+        $this,
+        'recaptcha_secret_key_on_callback',
+      ), // Callback
+      self::$section_name,
+      self::$section_id
     );
   }
 
-  public function admin_menu() {
+  public function admin_menu()
+  {
     $page_title = 'ASU RFI Plugin Settings';
     $menu_title = 'ASU RFI';
     $capability = 'manage_options';
-    $path = plugin_dir_url( __FILE__ );
+    $path = plugin_dir_url(__FILE__);
 
     add_options_page(
-        'Settings Admin',
-        'ASU RFI Form',
-        $capability,
-        self::$page_name,
-        array( $this, 'render_admin_page' )
+      'Settings Admin',
+      'ASU RFI Form',
+      $capability,
+      self::$page_name,
+      array($this, 'render_admin_page')
     );
-
   }
 
-  public function render_admin_page() {
+  public function render_admin_page()
+  {
     ?>
-    <div class="wrap">
-        <h1>ASU Request For Information Form Settings</h1>
-        <form method="post" action="options.php">
+<div class="wrap">
+    <h1>ASU Request For Information Form Settings</h1>
+    <form method="post" action="options.php">
         <?php
             // This prints out all hidden setting fields
-            settings_fields( self::$options_group );
-            do_settings_sections( self::$section_name );
-            submit_button();
+        settings_fields(self::$options_group);
+        do_settings_sections(self::$section_name);
+        submit_button();
         ?>
-        </form>
-    </div>
-    <?php
-  }
+    </form>
+</div>
+<?php
+
+}
 
 
-  /**
+/**
    * Print the section text
    */
-  public function print_section_info() {
-    print 'Enter your settings below:';
-  }
+public function print_section_info()
+{
+  print 'Enter your settings below:';
+}
 
-  /**
+/**
    * Print the form section for the college code
    */
-  public function college_code_on_callback() {
+public function college_code_on_callback()
+{
 
-    $value = $this->get_option_attribute_or_default(
-        array(
-          'name'      => self::$options_name,
-          'attribute' => self::$college_code_option_name,
-          'default'   => '',
-        )
-    );
+  $value = $this->get_option_attribute_or_default(
+    array(
+      'name'      => self::$options_name,
+      'attribute' => self::$college_code_option_name,
+      'default'   => '',
+    )
+  );
 
-    $html = <<<HTML
+  $html = <<<HTML
     <input type="text" id="%s" name="%s[%s]" value="%s"/><br/>
     <em>College Codes are used in the class program catalog, they usually are two or three characters long and in all caps. Also they can be found with `GR` or `UG` prefixes (for undergraduate or graduate courses), leave that prefix off.</em><br/>
     <span>Example: <strong>SU</strong> for `The School of Sustainbility`</span>
 HTML;
 
-    printf(
-        $html,
-        self::$college_code_option_name,
-        self::$options_name,
-        self::$college_code_option_name,
-        $value
-    );
-  }
+  printf(
+    $html,
+    self::$college_code_option_name,
+    self::$options_name,
+    self::$college_code_option_name,
+    $value
+  );
+}
 
-  /**
+/**
    * Print the form section for the source_id form element
    */
-  public function source_id_on_callback() {
+public function source_id_on_callback()
+{
 
-    $value = $this->get_option_attribute_or_default(
-        array(
-          'name'      => self::$options_name,
-          'attribute' => self::$source_id_option_name,
-          'default'   => '',
-        )
-    );
+  $value = $this->get_option_attribute_or_default(
+    array(
+      'name'      => self::$options_name,
+      'attribute' => self::$source_id_option_name,
+      'default'   => '',
+    )
+  );
 
-    $html = <<<HTML
+  $html = <<<HTML
     <input type="text" id="%s" name="%s[%s]" value="%s"/><br/>
     <em>Source Identifiers are granted by the <a href="mailto:ecomm@asu.edu
 ">ASU Enrollment Services Department</a>, please contact them to uptain a source_id for your college or department.</em>
 HTML;
 
-    printf(
-        $html,
-        self::$source_id_option_name,
-        self::$options_name,
-        self::$source_id_option_name,
-        $value
-    );
-  }
+  printf(
+    $html,
+    self::$source_id_option_name,
+    self::$options_name,
+    self::$source_id_option_name,
+    $value
+  );
+}
 
-  /**
+/**
+   * Print the form section for the reCAPTCHA secret key
+   */
+public function recaptcha_secret_key_on_callback()
+{
+
+  $value = $this->get_option_attribute_or_default(
+    array(
+      'name'      => self::$options_name,
+      'attribute' => self::$google_recaptcha_secret_option_name,
+      'default'   => '',
+    )
+  );
+
+  $html = <<<HTML
+    <input type="text" id="%s" name="%s[%s]" value="%s" size="40"/><br/>
+    <em>Enter the shared <b>secret</b> key from the appropriate Google reCAPTCHA account. This is <b>required</b>, and form submissions will not work without a reCAPTCHA key.</em>
+HTML;
+
+  printf(
+    $html,
+    self::$google_recaptcha_secret_option_name,
+    self::$options_name,
+    self::$google_recaptcha_secret_option_name,
+    $value
+  );
+}
+
+
+
+/**
    * Handle form submissions for validations
    */
-  public function form_submit( $input ) {
-    // intval the source_id_option_name
-    if ( isset( $input[ self::$source_id_option_name ] ) ) {
-      $input[ self::$source_id_option_name ] = intval( $input[ self::$source_id_option_name ] );
-    }
-
-    if ( isset( $input[ self::$college_code_option_name ] ) ) {
-      $input[ self::$college_code_option_name ] = strtoupper( $input[ self::$college_code_option_name ] );
-    }
-
-    return $input;
+public function form_submit($input)
+{
+  // intval the source_id_option_name
+  if (isset($input[self::$source_id_option_name])) {
+    $input[self::$source_id_option_name] = intval($input[self::$source_id_option_name]);
   }
 
+  // upper case the colege code
+  if (isset($input[self::$college_code_option_name])) {
+    $input[self::$college_code_option_name] = strtoupper($input[self::$college_code_option_name]);
+  }
+
+  // the reCAPTCHA secret key is not modified
+
+  return $input;
+}
 }

--- a/src/admin/asu-rfi-admin-page.php
+++ b/src/admin/asu-rfi-admin-page.php
@@ -24,6 +24,7 @@ class ASU_RFI_Admin_Page extends Hook
   public static $source_id_option_name = 'source_id';
   public static $college_code_option_name = 'college_code';
   public static $google_recaptcha_secret_option_name = 'recaptcha_secret_key';
+  public static $google_recaptcha_required_score_option_name = 'recaptcha_required_score';
   public static $section_id = 'asu-rfi-section_id';
   public static $section_name = 'asu-rfi-section_name';
   public static $page_name = 'asu-rfi-admin-page';
@@ -42,6 +43,7 @@ class ASU_RFI_Admin_Page extends Hook
         self::$source_id_option_name => 0,
         self::$college_code_option_name => null,
         self::$google_recaptcha_secret_option_name => '',
+        self::$google_recaptcha_required_score_option_name => 0.5,
       )
     );
 
@@ -108,6 +110,17 @@ class ASU_RFI_Admin_Page extends Hook
       array(
         $this,
         'recaptcha_secret_key_on_callback',
+      ), // Callback
+      self::$section_name,
+      self::$section_id
+    );
+
+    add_settings_field(
+      self::$google_recaptcha_required_score_option_name,
+      'reCAPTCHA Minimum Score',
+      array(
+        $this,
+        'recaptcha_default_score_on_callback',
       ), // Callback
       self::$section_name,
       self::$section_id
@@ -243,6 +256,32 @@ HTML;
   );
 }
 
+/**
+   * Print the form section for the reCAPTCHA secret key
+   */
+public function recaptcha_default_score_on_callback()
+{
+
+  $value = $this->get_option_attribute_or_default(
+    array(
+      'name'      => self::$options_name,
+      'attribute' => self::$google_recaptcha_required_score_option_name,
+      'default'   => '',
+    )
+  );
+
+  $html = '<select id="' . self::$google_recaptcha_required_score_option_name . '" name="' . self::$options_name . '[' .  self::$google_recaptcha_required_score_option_name . ']">';
+
+  for ($i = 0.0; $i <= 1.0; $i += 0.1) {
+    $selected = selected($value, $i, 0);
+    $html .= '<option value="' . $i . '"' . $selected . '>' . $i . '</option>';
+  }
+
+  $html .= '</select>';
+  $html .= '<p><em>Select the minimum required score for reCAPTCHA to allow an RFI form submission. A score of 0 means highly likely to be bad traffic (spammer/bot/etc.), while a score of 1 is highly likely to be good traffic. For public-facing forms, a level of 0.7 or higher is suggested.</em></p>';
+
+  echo $html;
+}
 
 
 /**

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -155,12 +155,8 @@ class ASU_RFI_Form_Shortcodes extends Hook
       )
     ));
     ensure_default($atts, 'semesters', null);
-
-
-
-    // shortcode attributes are always passed as strings. this ensures the value is parsed as a Boolean
-    // TRUE if 'true', 1, or 'on' is used (and FALSE otherwise.)
-    $atts['major_code_picker'] = filter_var($atts['major_code_picker'], FILTER_VALIDATE_BOOLEAN);
+    ensure_default($atts, 'thank_you_page', '');
+    ensure_default($atts, 'major_code_picker', 0);
 
     $view_data = array(
       'form_endpoint' => esc_url(admin_url('admin-post.php')), // since we're using callbacks on admin-post now
@@ -331,10 +327,10 @@ class ASU_RFI_Form_Shortcodes extends Hook
     // return a URL on a 200, and a WP_Error on any other code
     if (200 === $responseCode) {
       if (isset($_POST['thank_you']) && !empty($_POST['thank_you'])) {
-          // if we're redirecting to a page that is not our original form, then we don't need
-          // the querystring items, and can simply redirect.
-          return $_POST['thank_you'];
-        } else {
+        // if we're redirecting to a page that is not our original form, then we don't need
+        // the querystring items, and can simply redirect.
+        return $_POST['thank_you'];
+      } else {
         // if there is no thank_you page set, go back to the form page with querystring vars
         return $this->buildRedirectUrl($_POST['formUrl']);
       }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -1,5 +1,6 @@
 <?php
 namespace ASURFIWordPress\Shortcodes;
+
 use Honeycomb\Wordpress\Hook;
 use ASURFIWordPress\Services\ASUDegreeService;
 use ASURFIWordPress\Services\StudentTypeService;
@@ -10,50 +11,63 @@ use ASURFIWordPress\Admin\ASU_RFI_Admin_Page;
 use ASURFIWordPress\Helpers\ConditionalHelper;
 use ASURFIWordPress\Services\Client_Geocoding_Service;
 
-
 // Avoid direct calls to this file
-if ( ! defined( 'ASU_RFI_WORDPRESS_PLUGIN_VERSION' ) ) {
-  header( 'Status: 403 Forbidden' );
-  header( 'HTTP/1.1 403 Forbidden' );
+
+if (!defined('ASU_RFI_WORDPRESS_PLUGIN_VERSION')) {
+  header('Status: 403 Forbidden');
+  header('HTTP/1.1 403 Forbidden');
   exit();
 }
 
 /** ASU_RFI_Form_Shortcodes
  * provides the shortcode [asu-rfi-form]
  */
-class ASU_RFI_Form_Shortcodes extends Hook {
+class ASU_RFI_Form_Shortcodes extends Hook
+{
   use \ASURFIWordPress\Options_Handler_Trait;
 
   private $path_to_views;
   const PRODUCTION_FORM_ENDPOINT  = 'https://requestinfo.asu.edu/routing_form_post';
   const DEVELOPMENT_FORM_ENDPOINT = 'https://requestinfo-qa.asu.edu/routing_form_post';
+  const RECAPTCHA_URL = 'https://www.google.com/recaptcha/api/siteverify';
+  const RECAPTCHA_REQUIRED_SCORE = 0.7;
 
-  public function __construct() {
-    parent::__construct( 'asu-rfi-form-shortcodes', ASU_RFI_WORDPRESS_PLUGIN_VERSION );
+  public function __construct()
+  {
+    parent::__construct('asu-rfi-form-shortcodes', ASU_RFI_WORDPRESS_PLUGIN_VERSION);
     $this->path_to_views = __DIR__ . '/../views/';
     $this->define_hooks();
+    $this->currentEndPoint = self::PRODUCTION_FORM_ENDPOINT;
   }
 
-  public function define_hooks() {
-    $this->add_action( 'wp_enqueue_scripts', $this, 'wp_enqueue_scripts' );
-    $this->add_shortcode( 'asu-rfi-form', $this, 'asu_rfi_form' );
-    $this->add_action( 'init', $this, 'setup_rewrites' );
-    $this->add_action( 'wp', $this, 'add_http_cache_header' );
-    $this->add_action( 'wp_head', $this, 'add_html_cache_header' );
+  public function define_hooks()
+  {
+    $this->add_action('wp_enqueue_scripts', $this, 'wp_enqueue_scripts');
+    $this->add_shortcode('asu-rfi-form', $this, 'asu_rfi_form');
+    $this->add_action('init', $this, 'setup_rewrites');
+    $this->add_action('wp', $this, 'add_http_cache_header');
+    $this->add_action('wp_head', $this, 'add_html_cache_header');
+
+    // form handling callbacks. We capture POST requests from both logged-in and
+    // NOT logged-in users, and send them both to our RFI handling method.
+    $this->add_action('admin_post_nopriv_rfi_form', $this, 'rfi_post');
+    $this->add_action('admin_post_rfi_form', $this, 'rfi_post');
   }
 
   /**
    * Shorthand view wrapper to make rendering a view using nectary's factories easier in this plugin
    */
-  private function view( $template_name ) {
-    return new \Nectary\Factories\View_Factory( $template_name, $this->path_to_views );
+  private function view($template_name)
+  {
+    return new \Nectary\Factories\View_Factory($template_name, $this->path_to_views);
   }
 
   /**
    * Do not cache any sensitive form data - ASU Web Application Security Standards
    */
-  public function add_html_cache_header() {
-    if ( $this->current_page_has_rfi_shortcode() ) {
+  public function add_html_cache_header()
+  {
+    if ($this->current_page_has_rfi_shortcode()) {
       echo '<meta http-equiv="Pragma" content="no-cache"/>
             <meta http-equiv="Expires" content="-1"/>
             <meta http-equiv="Cache-Control" content="no-store,no-cache" />';
@@ -65,41 +79,45 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    * This call back needs to hook after send_headers since we depend on the $post variable
    * and that is not populated at the time of send_headers.
    */
-  public function add_http_cache_header() {
-    if ( $this->current_page_has_rfi_shortcode() ) {
-      header( 'Cache-Control: no-Cache, no-Store, must-Revalidate' );
-      header( 'Pragma: no-Cache' );
-      header( 'Expires: 0' );
+  public function add_http_cache_header()
+  {
+    if ($this->current_page_has_rfi_shortcode()) {
+      header('Cache-Control: no-Cache, no-Store, must-Revalidate');
+      header('Pragma: no-Cache');
+      header('Expires: 0');
     }
   }
 
   /**
    * Returns true if the page is using the [asu-rfi-form] shortcode, else false
    */
-  private function current_page_has_rfi_shortcode() {
+  private function current_page_has_rfi_shortcode()
+  {
     global $post;
-    return ( is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, 'asu-rfi-form' ) );
+    return (is_a($post, 'WP_Post') && has_shortcode($post->post_content, 'asu-rfi-form'));
   }
 
   /** Set up any url rewrites:
    * WordPress requires that you tell it that you are using
    * additional parameters.
    */
-  public function setup_rewrites() {
-    add_rewrite_tag( '%statusFlag%' , '([^&]+)' );
-    add_rewrite_tag( '%msg%' , '([^&]+)' );
+  public function setup_rewrites()
+  {
+    add_rewrite_tag('%statusFlag%', '([^&]+)');
+    add_rewrite_tag('%msg%', '([^&]+)');
   }
 
   /**
    * Enqueue CSS and JS
    * Hooks onto `wp_enqueue_scripts`.
    */
-  public function wp_enqueue_scripts() {
-    if ( $this->current_page_has_rfi_shortcode() ) {
-      $url_to_css_file = plugin_dir_url( dirname( dirname( __FILE__ ) ) ) . 'assets/css/asu-rfi.css';
-      wp_enqueue_style( $this->plugin_slug, $url_to_css_file, array(), $this->version );
-      $url_to_jquery_validator = plugin_dir_url( dirname( dirname( __FILE__ ) ) ) . 'bower_components/jquery-validation/dist/jquery.validate.min.js';
-      wp_enqueue_script( 'jquery-validation', $url_to_jquery_validator, array( 'jquery' ), '1.16.0', false );
+  public function wp_enqueue_scripts()
+  {
+    if ($this->current_page_has_rfi_shortcode()) {
+      $url_to_css_file = plugin_dir_url(dirname(dirname(__FILE__))) . 'assets/css/asu-rfi.css';
+      wp_enqueue_style($this->plugin_slug, $url_to_css_file, array(), $this->version);
+      $url_to_jquery_validator = plugin_dir_url(dirname(dirname(__FILE__))) . 'bower_components/jquery-validation/dist/jquery.validate.min.js';
+      wp_enqueue_script('jquery-validation', $url_to_jquery_validator, array('jquery'), '1.16.0', false);
     }
   }
 
@@ -120,91 +138,98 @@ class ASU_RFI_Form_Shortcodes extends Hook {
    *     semesters = comma-delimited list of semesters to which a student can apply for submission (values:
    *         fall, spring, summer)
    */
-  public function asu_rfi_form( $atts, $content = '' ) {
+  public function asu_rfi_form($atts, $content = '')
+  {
     // if there are no attributes passed then $atts is not an array, its a string
-    if ( ! is_array( $atts ) ) {
+    if (!is_array($atts)) {
       $atts = array();
     }
-    ensure_default( $atts, 'campus', null );
-    ensure_default( $atts, 'major_code', null );
-    ensure_default( $atts, 'degree_level', 'undergrad' );
-    ensure_default( $atts, 'college_program_code', $this->get_option_attribute_or_default(
-        array(
-                'name'      => ASU_RFI_Admin_Page::$options_name,
-                'attribute' => ASU_RFI_Admin_Page::$college_code_option_name,
-                'default'   => null,
-    ) ) );
-    ensure_default( $atts, 'semesters', null );
+    ensure_default($atts, 'campus', null);
+    ensure_default($atts, 'major_code', null);
+    ensure_default($atts, 'degree_level', 'undergrad');
+    ensure_default($atts, 'college_program_code', $this->get_option_attribute_or_default(
+      array(
+        'name'      => ASU_RFI_Admin_Page::$options_name,
+        'attribute' => ASU_RFI_Admin_Page::$college_code_option_name,
+        'default'   => null,
+      )
+    ));
+    ensure_default($atts, 'semesters', null);
+
+
 
     // shortcode attributes are always passed as strings. this ensures the value is parsed as a Boolean
     // TRUE if 'true', 1, or 'on' is used (and FALSE otherwise.)
-    $atts['major_code_picker'] = filter_var( $atts['major_code_picker'], FILTER_VALIDATE_BOOLEAN );
+    $atts['major_code_picker'] = filter_var($atts['major_code_picker'], FILTER_VALIDATE_BOOLEAN);
 
     $view_data = array(
-          'form_endpoint' => self::PRODUCTION_FORM_ENDPOINT,
-          'redirect_back_url' => get_permalink(),
-          'source_id' => $this->get_option_attribute_or_default(
-              array(
-                'name'      => ASU_RFI_Admin_Page::$options_name,
-                'attribute' => ASU_RFI_Admin_Page::$source_id_option_name,
-                'default'   => 0,
-              )
-          ),
-          'enrollment_terms' => ASUSemesterService::get_available_enrollment_terms( $atts['degree_level'], $atts['semesters'] ),
-          'student_types' => StudentTypeService::get_student_types(),
-          'college_program_code' => null,
-          'major_code_picker' => $atts['major_code_picker'],
-          'major_code' => $atts['major_code'],
-        );
+      'form_endpoint' => esc_url(admin_url('admin-post.php')), // since we're using callbacks on admin-post now
+      'thank_you' => $atts['thank_you_page'],
+      'formUrl' => get_permalink(),
+      'source_id' => $this->get_option_attribute_or_default(
+        array(
+          'name'      => ASU_RFI_Admin_Page::$options_name,
+          'attribute' => ASU_RFI_Admin_Page::$source_id_option_name,
+          'default'   => 0,
+        )
+      ),
+      'enrollment_terms' => ASUSemesterService::get_available_enrollment_terms($atts['degree_level'], $atts['semesters']),
+      'student_types' => StudentTypeService::get_student_types(),
+      'college_program_code' => null,
+      'major_code_picker' => $atts['major_code_picker'],
+      'major_code' => $atts['major_code']
+    );
 
-    if ( isset( $atts['test_mode'] ) && 0 === strcasecmp( 'test', $atts['test_mode'] ) ) {
+    // sets the hidden form element 'testmode'. Using this to determine which endpoint to use, as well.
+    if (isset($atts['test_mode']) && 0 === strcasecmp('test', $atts['test_mode'])) {
       $view_data['testmode'] = 'Test';
+      $this->currentEndPoint = self::DEVELOPMENT_FORM_ENDPOINT;
     } else {
       $view_data['testmode'] = 'Prod'; // default to production mode
+      $this->currentEndPoint = self::PRODUCTION_FORM_ENDPOINT;
     }
 
     // Use the attribute source id over the sites option
-    if ( isset( $atts['source_id'] ) ) {
-      $view_data['source_id'] = intval( $atts['source_id'] );
+    if (isset($atts['source_id'])) {
+      $view_data['source_id'] = intval($atts['source_id']);
     }
 
     // Use the attribute source id over the sites option
-    if ( ConditionalHelper::graduate( $atts['degree_level'] ) ) {
+    if (ConditionalHelper::graduate($atts['degree_level'])) {
       $view_data['degreeLevel'] = 'grad';
-      $view_data['student_types'] = StudentTypeService::get_student_types( 'grad' );
-    } elseif ( ConditionalHelper::undergraduate( $atts['degree_level'] ) ) {
+      $view_data['student_types'] = StudentTypeService::get_student_types('grad');
+    } elseif (ConditionalHelper::undergraduate($atts['degree_level'])) {
       $view_data['degreeLevel'] = 'ugrad';
-      $view_data['student_types'] = StudentTypeService::get_student_types( 'undergrad' );
+      $view_data['student_types'] = StudentTypeService::get_student_types('undergrad');
     }
 
     // get the Majors offered for this college, degree level and/or campus
-    if ( isset( $atts['college_program_code'] ) ) {
+    if (isset($atts['college_program_code'])) {
 
       $atts['college_program_code'] = ASUCollegeService::add_degree_level_prefix(
-          $atts['college_program_code'],
-          $view_data['degreeLevel']
+        $atts['college_program_code'],
+        $view_data['degreeLevel']
       );
 
       $view_data['college_program_code'] = $atts['college_program_code'];
 
-      if ( $atts['major_code_picker'] ) {
+      if ($atts['major_code_picker']) {
         $view_data['major_codes'] = ASUDegreeStore::get_programs(
-            $atts['college_program_code'],
-            $view_data['degreeLevel'],
-            $atts['campus']
+          $atts['college_program_code'],
+          $view_data['degreeLevel'],
+          $atts['campus']
         );
-
-      } elseif ( 'grad' === $view_data['degreeLevel'] && ! empty( $atts['major_code'] ) ) {
+      } elseif ('grad' === $view_data['degreeLevel'] && !empty($atts['major_code'])) {
         // since 'major code picker' is not used, if this is for a Graduate form
         // assign studentType to match the degree program (Masters, Doctoral, etc.)
         $programs = ASUDegreeStore::get_programs(
-            $atts['college_program_code'],
-            $view_data['degreeLevel'],
-            $atts['campus']
+          $atts['college_program_code'],
+          $view_data['degreeLevel'],
+          $atts['campus']
         );
         // find major code in college's available degrees
-        foreach ( $programs as $program ) {
-          if ( $program['value'] === $atts['major_code'] ) {
+        foreach ($programs as $program) {
+          if ($program['value'] === $atts['major_code']) {
             $view_data['student_type'] = $program['type'];
             break;
           }
@@ -212,36 +237,227 @@ class ASU_RFI_Form_Shortcodes extends Hook {
       }
     }
 
-    $view_data = $this->add_previous_submission_response( $view_data );
+    $view_data = $this->add_previous_submission_response($view_data);
 
     // Figure out which form to show
     $view_name = 'rfi-form.simple-request-info-form';
-    if ( isset( $atts['type'] ) && 0 === strcasecmp( 'full', $atts['type'] ) ) {
+    if (isset($atts['type']) && 0 === strcasecmp('full', $atts['type'])) {
       $view_name = 'rfi-form.form';
     }
 
-    $response = $this->view( $view_name )->add_data( $view_data )->build();
+    $response = $this->view($view_name)->add_data($view_data)->build();
     return $response->content;
   }
 
   /**
    * Look at the statusFlag and msg query var and return a human readable message that can be used
    */
-  private function add_previous_submission_response( $view_data ) {
-    $response_status_code = get_query_var( 'statusFlag' );
-    if ( $response_status_code ) {
-      $message = get_query_var( 'msg' );
+  private function add_previous_submission_response($view_data)
+  {
+    $response_status_code = get_query_var('statusFlag');
+    if ($response_status_code) {
+      $message = get_query_var('msg');
       // we have submitted the request form and should display a success or error message
-      if ( 200 === intval( $response_status_code ) ) {
+      if (200 === intval($response_status_code)) {
         $view_data['success_message'] = 'Thank you for your submission!';
         $view_data['client_geo_location'] = Client_Geocoding_Service::client_geo_location();
       } else {
-        error_log( 'error submitting ASU RFI (code: ' . $response_status_code . ') : ' . $message );
-        $view_data['error_message'] = $message ? 'Error:' . $message : 'Something went wrong with your submission';
+        error_log('error submitting ASU RFI (code: ' . $response_status_code . ') : ' . $message);
+        $view_data['error_message'] = $message ? 'Error: ' . $message : 'Something went wrong with your submission';
       }
     }
     return $view_data;
   }
 
 
+  /**
+   * rfi_post()
+   *
+   * Our callback method for the wp_admin_post hook. Called when a form is submitted to Wordpress
+   * that contains : <input type="hidden" name="action" value="rfi_form">. This is the logic only
+   * for submitted forms (it is not called on a regular page render).
+   */
+  public function rfi_post()
+  {
+    // Step 1: Send the token (from our form) to Google for a reCAPTCHA score.
+    $verified = $this->recaptcha_verify();
+
+    if (is_wp_error($verified)) {
+      $this->redirect_with_error($verified, $_POST['formUrl']);
+    }
+
+    // Step 2: submit the form to our endpoint and redirect to the URL we get back
+    $posted = $this->submit_form();
+
+    if (is_wp_error($posted)) {
+      $this->redirect_with_error($posted, $_POST['formUrl']);
+    }
+
+    // if it's all good, we can redirect to the URL that came back from our method call
+    wp_redirect($posted);
+    //exit;
+  }
+
+  /**
+   * submit_form()
+   *
+   * Submits the POST data to our endpoint, returning a URL for redirection or a WP_Error
+   * object if something did not work.
+   */
+  private function submit_form()
+  {
+    // the actual form submission doesn't need our reCAPTCHA stuff
+    unset($_POST['g-recaptcha-response']);
+    unset($_POST['action']);
+    unset($_POST['rfi-submit']);
+
+    // submit the form (using the Wordpress HTTP API)
+    $response = wp_remote_post(
+      $this->currentEndPoint,
+      array(
+        'body' => $_POST,
+        'timeout' => 10
+      )
+    );
+
+    /**
+    * retrieve the response code from our request. Based on my testing, the endpoint is
+    * using the standard 200 for success and 400 for an error.
+    */
+
+    // get the code
+    $responseCode = wp_remote_retrieve_response_code($response);
+
+    // return the URL for redirecting our user, or a WP_Error
+    if (200 === $responseCode) {
+      return $this->buildRedirectUrl($_POST['thank_you']);
+    } else {
+      return new \WP_Error('submit', ' ' . $response->get_error_message());
+    }
+  }
+
+  /**
+   * recaptcha_verify()
+   *
+   * Retrieves a reCAPTCHA v3 score for the current request's token. Returns TRUE on success, otherwise
+   * returns an instance of WP_Error with an appropriate message.
+   */
+  private function recaptcha_verify()
+  {
+    // make sure our form came through with the expected recaptcha token
+    if (isset($_POST['g-recaptcha-response']) && !empty($_POST['g-recaptcha-response'])) {
+      $token = $_POST['g-recaptcha-response'];
+    } else {
+      // we can't continue without the token, as it's required to verify with reCAPTCHA
+      return new \WP_Error('recaptcha', 'Unable to verify via Google reCAPTCHA. No user token.');
+    }
+
+    /**
+     * Google expects our secret key as well. It's stored in the plugin settings.
+     */
+    $secret_key = $this->get_option_attribute_or_default(
+      array(
+        'name'      => ASU_RFI_Admin_Page::$options_name,
+        'attribute' => ASU_RFI_Admin_Page::$google_recaptcha_secret_option_name,
+        'default'   => null,
+      )
+    );
+
+    // Use the WordPress HTTP API to make the request for a reCAPTCHA score
+    $data = [
+      'secret' => $secret_key,
+      'response' => $token,
+    ];
+
+    $recaptchaResult = wp_remote_post(self::RECAPTCHA_URL, array(
+      'body' => $data,
+    ));
+
+    // check to see if we got an error object.
+    if (is_wp_error($recaptchaResult)) {
+      return $recaptchaResult;
+    }
+
+    // decode our results, which are in the 'body' key of the array we get back
+    // from wp_remote_post()
+    $result = json_decode($recaptchaResult['body']);
+
+    /**
+     * the Google JSON will contain (among other fields):
+     * - a 'success' field with either TRUE or FALSE
+     * - a 'score' field (only on success) with a score between 0 and 1
+     * - an 'error-codes' field (only on error) with one, or more, erorr messages
+     */
+    if ($result->success) {
+      // we got a score, but was it good enough?
+      if ($result->score >= self::RECAPTCHA_REQUIRED_SCORE) {
+        // Yes! You passed!
+        return true;
+      } else {
+        // No! You are a bot!
+        return new \WP_Error('recaptcha', 'Insufficient score reported by Google reCAPTCHA');
+      }
+    } else {
+      // we did NOT get a score. Gather the Google error(s) and return it/them.
+      $my_error = new \WP_Error();
+
+      // note: curly braces required here because of the dash in the property's name. Normally, you
+      // would type $result->error-codes, but that's not valid in PHP.
+      foreach ($result->{'error-codes'} as $thisError) {
+        $my_error->add('recaptcha', ' Google reCAPTCHA reported ' . $thisError);
+      }
+
+      return $my_error;
+    }
+  }
+
+  /**
+   * redirect_with_error( WP_Error $error, String $url)
+   *
+   * Takes a WP_Error object and a URL, then redirects the user back to the RFI form with
+   * the statusFlag set to 400 (to display as an error), and the first error message in the
+   * object.
+   */
+  private function redirect_with_error($error, $url)
+  {
+
+    // clean up the URL
+    $location = esc_url_raw($url);
+
+    // retrieve the error message from the WP_Error object. WP_Error uses an array, and the
+    // keys of the array are called error 'codes', so we're grabbing the first array key in
+    // order to get its associated message.
+    $code = $error->get_error_code();
+    $message = $error->get_error_message($code);
+
+    // Add a 400 code, and the error message, to the query string - using the names our
+    // own code is expecting
+    $location = add_query_arg('statusFlag', urlencode('400'), $location);
+    $location = add_query_arg('msg', urlencode($message), $location);
+
+    // send the user back to the form (hopefully), and display the error message
+    wp_redirect($location);
+    exit;
+  }
+
+  /**
+   * Construct a success URL by appending the expected query string variables:
+   *
+   * statusFlag = 200 (this method only deals with successful submissions)
+   * msg = a message to display. The add_previous_submission_response() method above
+   * will use a default if none is provided here.
+   */
+  private function buildRedirectUrl($url)
+  {
+    // trim trailing slashes that may be on the URL, as we need to append query string items
+    $redirectUrl = rtrim($url, '/');
+
+    // add our success code and message
+    $redirectUrl = add_query_arg(array(
+      'statusFlag' => urlencode(200),
+      'msg' => urlencode('Your request has been processed. Thank you for your interest!')
+    ), $redirectUrl);
+
+    return $redirectUrl;
+  }
 }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -328,9 +328,16 @@ class ASU_RFI_Form_Shortcodes extends Hook
     // get the code
     $responseCode = wp_remote_retrieve_response_code($response);
 
-    // return the URL for redirecting our user, or a WP_Error
+    // return a URL on a 200, and a WP_Error on any other code
     if (200 === $responseCode) {
-      return $this->buildRedirectUrl($_POST['thank_you']);
+      if (isset($_POST['thank_you']) && !empty($_POST['thank_you'])) {
+          // if we're redirecting to a page that is not our original form, then we don't need
+          // the querystring items, and can simply redirect.
+          return $_POST['thank_you'];
+        } else {
+        // if there is no thank_you page set, go back to the form page with querystring vars
+        return $this->buildRedirectUrl($_POST['formUrl']);
+      }
     } else {
       return new \WP_Error('submit', ' ' . $response->get_error_message());
     }

--- a/src/views/rfi-form/recaptcha-javascript.handlebars
+++ b/src/views/rfi-form/recaptcha-javascript.handlebars
@@ -1,0 +1,8 @@
+<script src="https://www.google.com/recaptcha/api.js?render=6Ldlq40UAAAAAASePPra7bfEVU0Le5uDJzNRG_6j"></script>
+<script>
+    grecaptcha.ready(function () {
+        grecaptcha.execute('6Ldlq40UAAAAAASePPra7bfEVU0Le5uDJzNRG_6j', { action: 'rfi' }).then(function (token) {
+            $('#g-recaptcha-response').val(token);
+        });
+    });
+</script>

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -1,39 +1,47 @@
 {{#if success_message }}
-  <div class="alert alert-success" role="alert">
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-    {{ success_message }}
-  </div>
-  {{> rfi-form/completion-analytics }}
+<div class="alert alert-success" role="alert">
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span
+      aria-hidden="true">&times;</span></button>
+  {{ success_message }}
+</div>
+{{> rfi-form/completion-analytics }}
 {{/if}}
 {{#if error_message }}
-  <div class="alert alert-danger" role="alert">
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-    {{ error_message }}
-  </div>
+<div class="alert alert-danger" role="alert">
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span
+      aria-hidden="true">&times;</span></button>
+  {{ error_message }}
+</div>
 {{/if}}
 
 <form method="post" action="{{ form_endpoint }}" class="asu-rfi-form">
   <input type="hidden" name="degreeLevel" value="{{ degreeLevel }}">
   <input type="hidden" name="testmode" value="{{ testmode }}">
-  <input type="hidden" name="formUrl" value="{{ redirect_back_url }}">
+  <input type="hidden" name="thank_you" value="{{ thank_you }}">
+  <input type="hidden" name="formUrl" value="{{ formUrl }}">
   <input type="hidden" name="source_id" value="{{ source_id }}">
+  <input type="hidden" name="action" value="rfi_form">
   <div class='honey'><input type="text" name="email"></div>
 
   <div class="form-group required has-feedback">
     <label class="control-label" for="firstName">First Name</label>
-    <input type="text" class="form-control" id="firstName" name="firstName" value="{{ first_name }}" placeholder="First Name" maxlength="40" required aria-required="true">
+    <input type="text" class="form-control" id="firstName" name="firstName" value="{{ first_name }}"
+      placeholder="First Name" maxlength="40" required aria-required="true">
   </div>
   <div class="form-group required has-feedback">
     <label class="control-label" for="lastName">Last Name</label>
-    <input type="text" class="form-control" id="lastName" name="lastName" value="{{ last_name }}" placeholder="Last Name" maxlength="50" required aria-required="true">
+    <input type="text" class="form-control" id="lastName" name="lastName" value="{{ last_name }}"
+      placeholder="Last Name" maxlength="50" required aria-required="true">
   </div>
   <div class="form-group required has-feedback">
     <label class="control-label" for="emailAddress">Email</label>
-    <input type="email" class="form-control" id="emailAddress" name="emailAddress" value="{{ email }}" placeholder="Email@example.com" maxlength="50" required aria-required="true">
+    <input type="email" class="form-control" id="emailAddress" name="emailAddress" value="{{ email }}"
+      placeholder="Email@example.com" maxlength="50" required aria-required="true">
   </div>
   <div class="form-group required has-feedback">
     <label class="control-label" for="phoneNumber">Phone</label>
-    <input type="text" class="form-control" id="phoneNumber" name="phoneNumber" value="{{ phoneNumber }}" placeholder='(123) 456-7890' maxlength="30" required aria-required="true">
+    <input type="text" class="form-control" id="phoneNumber" name="phoneNumber" value="{{ phoneNumber }}"
+      placeholder='(123) 456-7890' maxlength="30" required aria-required="true">
   </div>
   {{#if_cond degreeLevel '==' 'ugrad'}}
   <div class="form-group required has-feedback">
@@ -41,59 +49,61 @@
     <select name="StudentType" id="StudentType" class="form-control" required aria-required="true">
       <option value="" selected="selected">-</option>
       {{#each student_types }}
-        <option value="{{ value }}">{{ label }}</option>
+      <option value="{{ value }}">{{ label }}</option>
       {{/each}}
     </select>
   </div>
   {{/if_cond}}
 
   {{#if college_program_code }}
-    <input type="hidden" name="collegeOfInterest" value="{{ college_program_code }}">
+  <input type="hidden" name="collegeOfInterest" value="{{ college_program_code }}">
   {{/if}}
 
   {{#if major_code }}
-    <input type="hidden" name="poiCode" value="{{ major_code }}">
+  <input type="hidden" name="poiCode" value="{{ major_code }}">
   {{/if}}
   {{#if student_type }}
-    <input type="hidden" name="StudentType" value="{{ student_type }}">
+  <input type="hidden" name="StudentType" value="{{ student_type }}">
   {{/if}}
 
   {{#if major_codes }}
-    <div class="form-group required has-feedback">
-      <label class="control-label" for="poiCode">{{#if_cond degreeLevel '==' 'ugrad'}}Major{{else}}My program of interest{{/if_cond}}</label>
-      <select name="poiCode" id="poiCode" class="form-control" required aria-required="true">
-        <option value="" selected="selected">-</option>
-        {{#each major_codes }}
-          <option value="{{ value }}" data-program-type="{{type}}">{{ label }}</option>
-        {{/each}}
-      </select>
-    </div>
+  <div class="form-group required has-feedback">
+    <label class="control-label" for="poiCode">{{#if_cond degreeLevel '==' 'ugrad'}}Major{{else}}My program of
+      interest{{/if_cond}}</label>
+    <select name="poiCode" id="poiCode" class="form-control" required aria-required="true">
+      <option value="" selected="selected">-</option>
+      {{#each major_codes }}
+      <option value="{{ value }}" data-program-type="{{type}}">{{ label }}</option>
+      {{/each}}
+    </select>
+  </div>
   {{/if}}
 
-  {{#if_cond degreeLevel '==' 'grad'}} {{! On grad forms, move the StudentType field after POICode because StudentType will be auto-selected }}
-    {{#unless student_type }} {{! If shortcode hasn't pre-selected the studentType, render dropdown }}
-      <div class="form-group required has-feedback">
-        <label class="control-label" for="StudentType">I will be a future</label>
-        <select name="StudentType" id="StudentType" class="form-control" required aria-required="true">
-          <option value="" selected="selected">-</option>
-          {{#each student_types }}
-            <option value="{{ value }}">{{ label }}</option>
-          {{/each}}
-        </select>
-      </div>
-    {{/unless}}
+  {{#if_cond degreeLevel '==' 'grad'}}
+  {{! On grad forms, move the StudentType field after POICode because StudentType will be auto-selected }}
+  {{#unless student_type }} {{! If shortcode hasn't pre-selected the studentType, render dropdown }}
+  <div class="form-group required has-feedback">
+    <label class="control-label" for="StudentType">I will be a future</label>
+    <select name="StudentType" id="StudentType" class="form-control" required aria-required="true">
+      <option value="" selected="selected">-</option>
+      {{#each student_types }}
+      <option value="{{ value }}">{{ label }}</option>
+      {{/each}}
+    </select>
+  </div>
+  {{/unless}}
   {{/if_cond}}
 
   {{#if enrollment_terms }}
-    <div class="form-group required has-feedback">
-      <label class="control-label" for="projectedEnrollment">My anticipated start date</label>
-      <select name="projectedEnrollment" id="projectedEnrollment" class="form-control" required aria-required="true">
-        <option value="" selected="selected">-</option>
-        {{#each enrollment_terms }}
-          <option value="{{ value }}">{{ label }}</option>
-        {{/each}}
-      </select>
-    </div>
+  <div class="form-group required has-feedback">
+    <label class="control-label" for="projectedEnrollment">My anticipated start date</label>
+    <select name="projectedEnrollment" id="projectedEnrollment" class="form-control" required aria-required="true">
+      <option value="" selected="selected">-</option>
+      {{#each enrollment_terms }}
+      <option value="{{ value }}">{{ label }}</option>
+      {{/each}}
+    </select>
+  </div>
   {{/if}}
 
   <div class="form-group has-feedback">
@@ -102,7 +112,9 @@
   </div>
 
   <div class="form-group">
-    <input type="submit" value="Submit" class="btn btn-default" aria-label="Submit Request">
+    <input type="submit" name="rfi-submit" value="Submit" class="btn btn-default" aria-label="Submit Request">
+    <input type="hidden" id="g-recaptcha-response" name="g-recaptcha-response" value="" />
   </div>
 </form>
 {{> rfi-form/form-javascript }}
+{{> rfi-form/recaptcha-javascript }}


### PR DESCRIPTION
This is pretty big change to the plugin, including:

**Adding Google reCAPTCHA (v3)**
Each time a page with an RFI form is requested, Google will evaluate the page request and assign it a score between zero and one. We then receive a token from Google for looking up that score on the back-end. When we retrieve the score, we compare it to our minimum required value (set in the plugin) and reject any attempt to submit a form with a failing score (i.e. we don't even submit to the ASU endpoint).

This necessitated changing how we handle form processing. Previously, the ASU endpoint was part of the actual form itself (`<form action="{asu-endpoint-here}" method="post>`), but we now submit the form back to WordPress. In WordPress, the `admin_post.php` script fires off a callback method where we use the WordPress HTTP API to get the reCAPTCHA score, and to POST the form to the ASU endpoint. By submitting the form to ourselves, we have access to the form values before/after submitting anything to the ASU endpoint. This opened up more possibilities, including the other new feature...

**Custom Thank You Pages**
A new shortcode attribute, `thank_you_page` is now available, allowing us to provide a URL for redirecting after a successful form submission. If a submission comes back from the ASU endpoint with a success message, we can now look at the POST values we used to submit the form and redirect the user to the `thank_you_page` URL from the shortcode (as we store that value in a hidden form field).

**Other Changes**
- updates to the readme file
- small changes to make _most_ of our unit tests pass
- Added a field to the plugin's admin screen for storing our Google reCAPTCHA secret key, and the minimum reCAPTCHA score we will accept.