### PR TITLE
Bug Fixes / Improvements / GuzzleHTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ WordPress plugin to submit Request For Information requests into Salesforce
   * **college_program_code** = 2-5 character string, usually all caps, eg `LA` for `College of Liberal Arts and Sciences` or `SU` for `School of Sustainability`, it will default to the value set in the RFI Admin Options menu so only use this attribute if you want to override one specific form.
   * **campus** = eg `TEMPE` or leave blank for all Campuses.
   * **semesters** = comma-delimited list of semesters allowed to be selected in 'My anticipated start date' dropdown (eg: `spring,summer,fall`). If omitted, the dropdown will be auto-filled with Spring, Summer, Fall for Undergrad Forms, and Spring, Fall for Grad Forms.
+  * **test_mode** = either 'test' or 'prod' (anything other than the literal string 'test', including not having this attribute at all, will result in 'prod'). The use of this flag by the actual endpoint is uknown to us, but it's here just in case you need to specify it.
+  * **endpoint** = either 'test' or 'prod' (anything other than the literal string 'test', including not having this attribute at all, will result in 'prod'). Determines which RFI endpoint is used. Setting this to 'test' will send requests to the QA endpoint where, presumably, the **do not** end result in actual submissions to SalesForce.
   * **thank_you_page** = A URL to which we will send the user after an RFI submission has received a passing grade from Google's reCAPTCHA system, and was successfully submitted. To redirect to a page that is already set up in Wordpress, you can use a relative URL, as in `/about/thank-you`.
 
 ### Available Major Codes for SOS

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ WordPress plugin to submit Request For Information requests into Salesforce
 * [GitHub Updater WordPress Plugin](https://github.com/afragen/github-updater)
 * The active theme should have a recent verson of Twitter Boostrap.
 
+# Install Notes
+Please note that you will need to run `composer install` and `yarn` in the project directory to bring in all required libraries.
+
 
 # Site Settings
 ![screen shot 2016-12-13 at 12 43 24 pm](https://cloud.githubusercontent.com/assets/295804/21156084/c728ccae-c131-11e6-8e0f-7cbc1a6e3db6.png)

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "gios-asu/nectary": "^0.2.2",
     "gios-asu/honeycomb": "^1.0.4",
     "phpxmlrpc/phpxmlrpc": "^4.0",
-    "phine/country": "^1.1"
+    "phine/country": "^1.1",
+    "guzzlehttp/guzzle": "~6.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8",

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "208a9ff7758c3483df9824fa1b481ed5",
-    "content-hash": "0413de5816360e56de782b39a05f4823",
+    "content-hash": "85fb8d4de324a1db307dda416be18e8c",
     "packages": [
         {
             "name": "coduo/php-humanizer",
@@ -66,7 +65,7 @@
                 "humanizer",
                 "php"
             ],
-            "time": "2016-02-21 12:53:26"
+            "time": "2016-02-21T12:53:26+00:00"
         },
         {
             "name": "gios-asu/honeycomb",
@@ -99,7 +98,7 @@
                 }
             ],
             "description": "A framework for WordPress plugins",
-            "time": "2017-02-27 17:39:34"
+            "time": "2017-02-27T17:39:34+00:00"
         },
         {
             "name": "gios-asu/nectary",
@@ -145,7 +144,190 @@
                 }
             ],
             "description": "A simple PHP framework that is not tied to a web interface",
-            "time": "2016-11-15 20:46:34"
+            "time": "2016-11-15T20:46:34+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2018-04-22T15:46:56+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "9f83dded91781a01c63574e387eaa769be769115"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9f83dded91781a01c63574e387eaa769be769115",
+                "reference": "9f83dded91781a01c63574e387eaa769be769115",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "time": "2018-12-04T20:46:45+00:00"
         },
         {
             "name": "phine/country",
@@ -198,7 +380,7 @@
                 "country"
             ],
             "abandoned": true,
-            "time": "2015-04-21 03:50:08"
+            "time": "2015-04-21T03:50:08+00:00"
         },
         {
             "name": "phine/exception",
@@ -248,7 +430,7 @@
                 "exception"
             ],
             "abandoned": true,
-            "time": "2013-08-27 17:43:25"
+            "time": "2013-08-27T17:43:25+00:00"
         },
         {
             "name": "phpxmlrpc/phpxmlrpc",
@@ -299,7 +481,97 @@
                 "webservices",
                 "xmlrpc"
             ],
-            "time": "2016-10-01 12:29:37"
+            "time": "2016-10-01T12:29:37+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7.0",
+                "satooshi/php-coveralls": ">=1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2016-02-11T07:05:27+00:00"
         },
         {
             "name": "symfony/config",
@@ -352,7 +624,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-25 08:27:07"
+            "time": "2016-09-25T08:27:07+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -401,7 +673,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-18 04:30:12"
+            "time": "2016-10-18T04:30:12+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -460,7 +732,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/translation",
@@ -524,7 +796,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-18 04:30:12"
+            "time": "2016-10-18T04:30:12+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -573,7 +845,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-24 18:41:13"
+            "time": "2016-10-24T18:41:13+00:00"
         },
         {
             "name": "xamin/handlebars.php",
@@ -615,7 +887,7 @@
             ],
             "description": "Handlebars processor for php",
             "homepage": "https://github.com/XaminProject/handlebars.php",
-            "time": "2015-08-06 22:16:36"
+            "time": "2015-08-06T22:16:36+00:00"
         }
     ],
     "packages-dev": [
@@ -671,7 +943,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "guzzle/guzzle",
@@ -767,7 +1039,7 @@
                 "web service"
             ],
             "abandoned": "guzzlehttp/guzzle",
-            "time": "2015-03-18 18:23:50"
+            "time": "2015-03-18T18:23:50+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -821,7 +1093,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -866,7 +1138,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -913,7 +1185,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-06-10T07:14:17+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -975,7 +1247,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-06-07T08:13:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1037,7 +1309,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1084,7 +1356,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2015-06-21T13:08:43+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1125,7 +1397,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -1169,7 +1441,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2016-05-12 18:03:57"
+            "time": "2016-05-12T18:03:57+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -1218,7 +1490,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2015-09-15T10:49:45+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1290,7 +1562,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-11-14 06:25:28"
+            "time": "2016-11-14T06:25:28+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1346,7 +1618,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "psr/log",
@@ -1393,7 +1665,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "satooshi/php-coveralls",
@@ -1451,7 +1723,7 @@
                 "github",
                 "test"
             ],
-            "time": "2016-01-20 17:35:46"
+            "time": "2016-01-20T17:35:46+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -1515,7 +1787,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2015-07-26T15:48:44+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -1567,7 +1839,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1617,7 +1889,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1684,7 +1956,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1735,7 +2007,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -1788,7 +2060,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-11-15 06:55:36"
+            "time": "2016-11-15T06:55:36+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1823,7 +2095,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1901,7 +2173,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-09-01 23:53:02"
+            "time": "2016-09-01T23:53:02+00:00"
         },
         {
             "name": "symfony/console",
@@ -1962,7 +2234,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-06 01:44:51"
+            "time": "2016-10-06T01:44:51+00:00"
         },
         {
             "name": "symfony/debug",
@@ -2019,7 +2291,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 11:02:40"
+            "time": "2016-09-06T11:02:40+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -2079,7 +2351,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-13 01:43:15"
+            "time": "2016-10-13T01:43:15+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -2128,7 +2400,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29 05:41:56"
+            "time": "2016-06-29T05:41:56+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -2178,7 +2450,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2016-08-09T15:02:57+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -2214,7 +2486,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2016-08-29 20:04:47"
+            "time": "2016-08-29T20:04:47+00:00"
         }
     ],
     "aliases": [],

--- a/src/admin/asu-rfi-admin-page.php
+++ b/src/admin/asu-rfi-admin-page.php
@@ -24,6 +24,7 @@ class ASU_RFI_Admin_Page extends Hook
   public static $source_id_option_name = 'source_id';
   public static $college_code_option_name = 'college_code';
   public static $google_recaptcha_secret_option_name = 'recaptcha_secret_key';
+  public static $google_recaptcha_site_option_name = 'recaptcha_site_key';
   public static $google_recaptcha_required_score_option_name = 'recaptcha_required_score';
   public static $section_id = 'asu-rfi-section_id';
   public static $section_name = 'asu-rfi-section_name';
@@ -43,6 +44,7 @@ class ASU_RFI_Admin_Page extends Hook
         self::$source_id_option_name => 0,
         self::$college_code_option_name => null,
         self::$google_recaptcha_secret_option_name => '',
+        self::$google_recaptcha_site_option_name => '',
         self::$google_recaptcha_required_score_option_name => 0.5,
       )
     );
@@ -110,6 +112,17 @@ class ASU_RFI_Admin_Page extends Hook
       array(
         $this,
         'recaptcha_secret_key_on_callback',
+      ), // Callback
+      self::$section_name,
+      self::$section_id
+    );
+
+    add_settings_field(
+      self::$google_recaptcha_site_option_name,
+      'reCAPTCHA Site (public) Key',
+      array(
+        $this,
+        'recaptcha_site_key_on_callback',
       ), // Callback
       self::$section_name,
       self::$section_id
@@ -233,7 +246,6 @@ HTML;
    */
 public function recaptcha_secret_key_on_callback()
 {
-
   $value = $this->get_option_attribute_or_default(
     array(
       'name'      => self::$options_name,
@@ -244,7 +256,7 @@ public function recaptcha_secret_key_on_callback()
 
   $html = <<<HTML
     <input type="text" id="%s" name="%s[%s]" value="%s" size="40"/><br/>
-    <em>Enter the shared <b>secret</b> key from the appropriate Google reCAPTCHA account. This is <b>required</b>, and form submissions will not work without a reCAPTCHA key.</em>
+    <em><b>Required:</b> Enter the <b>secret</b> key from the appropriate Google reCAPTCHA account.</em>
 HTML;
 
   printf(
@@ -258,6 +270,36 @@ HTML;
 
 /**
    * Print the form section for the reCAPTCHA secret key
+   */
+public function recaptcha_site_key_on_callback()
+{
+  $value = $this->get_option_attribute_or_default(
+    array(
+      'name'      => self::$options_name,
+      'attribute' => self::$google_recaptcha_site_option_name,
+      'default'   => '',
+    )
+  );
+
+  $html = <<<HTML
+  <input type="text" id="%s" name="%s[%s]" value="%s" size="40"/><br/>
+  <em><b>Required:</b> Enter the public <b>site</b> key from the appropriate Google reCAPTCHA account.</em>
+HTML;
+
+
+  printf(
+    $html,
+    self::$google_recaptcha_site_option_name,
+    self::$options_name,
+    self::$google_recaptcha_site_option_name,
+    $value
+  );
+}
+
+
+
+/**
+   * Print the form section for the reCAPTCHA minimum scores
    */
 public function recaptcha_default_score_on_callback()
 {

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -318,9 +318,15 @@ class ASU_RFI_Form_Shortcodes extends Hook
       $this->currentEndPoint,
       array(
         'body' => $_POST,
-        'timeout' => 10
+        'timeout' => 20
       )
     );
+
+    // wp_remote_post() returns an array of data on success, and a WP_Error object on failure
+    if (is_wp_error($response)) {
+      return $response;
+    }
+
 
     /**
     * retrieve the response code from our request. Based on my testing, the endpoint is
@@ -329,6 +335,10 @@ class ASU_RFI_Form_Shortcodes extends Hook
 
     // get the code
     $responseCode = wp_remote_retrieve_response_code($response);
+    $responseMessage = wp_remote_retrieve_response_message($response);
+    if (empty($responseMessage)) {
+      $responseMessage = 'An unknown error occurred.';
+    }
 
     // return a URL on a 200, and a WP_Error on any other code
     if (200 === $responseCode) {
@@ -341,7 +351,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
         return $this->buildRedirectUrl($_POST['formUrl']);
       }
     } else {
-      return new \WP_Error('submit', ' ' . wp_remote_retrieve_response_message($response));
+      return new \WP_Error('submit', ' ' . $responseMessage);
     }
   }
 

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -342,17 +342,18 @@ class ASU_RFI_Form_Shortcodes extends Hook
         $this->currentEndPoint = self::PRODUCTION_FORM_ENDPOINT;
     }
     error_log('Posting to endpoint: ' . $this->currentEndPoint);
-
+    $start = time();
+    error_log('Starting at ' . $start);
     // submit the form (using the Wordpress HTTP API)
     $response = wp_remote_post(
       $this->currentEndPoint,
       array(
         'body' => $_POST,
-        //'timeout' => 20,
       )
     );
-
-    error_log('Post complete...');
+    $end = time();
+    $diff = $start - $end;
+    error_log('Post complete at: ' . $end . '(' . $diff . ' seconds)');
 
     // wp_remote_post() returns an array of data on success, and a WP_Error object on failure
     if (is_wp_error($response)) {
@@ -539,6 +540,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
   public function rfi_request_timeout($time)
   {
     // This works only if you don't set a timeout in the wp_remote_post() call itself
+
     return 20;
   }
 }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -51,6 +51,9 @@ class ASU_RFI_Form_Shortcodes extends Hook
     // NOT logged-in users, and send them both to our RFI handling method.
     $this->add_action('admin_post_nopriv_rfi_form', $this, 'rfi_post');
     $this->add_action('admin_post_rfi_form', $this, 'rfi_post');
+
+    // an attempt to extend the wp_remote_post() timeout
+    $this->add_filter('http_request_timeout', 'rfi_request_timeout');
   }
 
   /**
@@ -519,5 +522,11 @@ class ASU_RFI_Form_Shortcodes extends Hook
     ), $redirectUrl);
 
     return $redirectUrl;
+  }
+
+  public function rfi_request_timeout()
+  {
+    // not sure if setting this in wp_remote_post() is actually working. Trying this method.
+    return 20;
   }
 }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -53,7 +53,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
     $this->add_action('admin_post_rfi_form', $this, 'rfi_post');
 
     // an attempt to extend the wp_remote_post() timeout
-    $this->add_filter('http_request_timeout', 'rfi_request_timeout');
+    $this->add_filter('http_request_timeout', $this, 'rfi_request_timeout');
   }
 
   /**

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -334,7 +334,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
         return $this->buildRedirectUrl($_POST['formUrl']);
       }
     } else {
-      return new \WP_Error('submit', ' ' . $response->get_error_message());
+      return new \WP_Error('submit', ' ' . wp_remote_retrieve_response_message($response));
     }
   }
 

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -129,6 +129,11 @@ class ASU_RFI_Form_Shortcodes extends Hook
       wp_enqueue_style($this->plugin_slug, $url_to_css_file, array(), $this->version);
       $url_to_jquery_validator = plugin_dir_url(dirname(dirname(__FILE__))) . 'node_modules/jquery-validation/dist/jquery.validate.min.js';
       wp_enqueue_script('jquery-validation', $url_to_jquery_validator, array('jquery'), '1.16.0', false);
+
+      // dequeue ContactForm7, as their reCAPTCHA code creates a token on page load, which can
+      // expire before the form is submitted (tokens are only good for a few minutes)
+      wp_dequeue_script('contact-form-7');
+      wp_dequeue_style('contact-form-7');
     }
   }
 
@@ -292,7 +297,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
         $view_data['client_geo_location'] = Client_Geocoding_Service::client_geo_location();
       } else {
         error_log('error submitting ASU RFI (code: ' . $response_status_code . ') : ' . $message);
-        $view_data['error_message'] = $message ?'Error: ' . $message : 'Something went wrong with your submission';
+        $view_data['error_message'] = $message ? 'Error: ' . $message : 'Something went wrong with your submission';
       }
     }
     return $view_data;

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -168,6 +168,13 @@ class ASU_RFI_Form_Shortcodes extends Hook
           'default'   => 0,
         )
       ),
+      'site_key' => $this->get_option_attribute_or_default(
+        array(
+          'name'      => ASU_RFI_Admin_Page::$options_name,
+          'attribute' => ASU_RFI_Admin_Page::$google_recaptcha_site_option_name,
+          'default'   => null,
+        )
+      ),
       'enrollment_terms' => ASUSemesterService::get_available_enrollment_terms($atts['degree_level'], $atts['semesters']),
       'student_types' => StudentTypeService::get_student_types(),
       'college_program_code' => null,

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -321,7 +321,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
         break;
       case 'Prod':
       default:
-        $this->currentEndPoint = self::PRODUCTION_FORM_ENDPOINT
+        $this->currentEndPoint = self::PRODUCTION_FORM_ENDPOINT;
     }
 
     // submit the form (using the Wordpress HTTP API)

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -172,7 +172,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
     ensure_default($atts, 'semesters', null);
     ensure_default($atts, 'thank_you_page', '');
     ensure_default($atts, 'major_code_picker', 0);
-    ensure_defaults($atts, 'endpoint', 'prod');
+    ensure_default($atts, 'endpoint', 'prod');
 
     error_log('Creating view data...');
 
@@ -358,6 +358,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
       default:
         $this->currentEndPoint = self::PRODUCTION_FORM_ENDPOINT;
     }
+    unset($_POST['endpoint']);
     error_log('Posting to endpoint: ' . $this->currentEndPoint);
     $start = time();
     error_log('Starting at ' . $start);
@@ -412,12 +413,14 @@ class ASU_RFI_Form_Shortcodes extends Hook
     // return a URL on a 200, and a WP_Error on any other code
     if (200 === $statusCode) {
       error_log('Result was a 200. Redirecting...');
-      if (isset($_POST['thank_you']) && !empty($_POST['thank_you'])) {
+      if (isset($thank_you_page) && !empty($thank_you_page)) {
         // if we're redirecting to a page that is not our original form, then we don't need
         // the querystring items, and can simply redirect.
-        return $_POST['thank_you'];
+        error_log('Thank you page is set: ' . $thank_you_page . '...');
+        return $thank_you_page;
       } else {
         // if there is no thank_you page set, go back to the form page with querystring vars
+        error_log('No thank you page set. Returning to original form page...');
         return $this->buildRedirectUrl($_POST['formUrl']);
       }
     } else {

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -57,9 +57,6 @@ class ASU_RFI_Form_Shortcodes extends Hook
     // NOT logged-in users, and send them both to our RFI handling method.
     $this->add_action('admin_post_nopriv_rfi_form', $this, 'rfi_post');
     $this->add_action('admin_post_rfi_form', $this, 'rfi_post');
-
-    // an attempt to extend the wp_remote_post() timeout
-    $this->add_filter('http_request_timeout', $this, 'rfi_request_timeout');
   }
 
   /**
@@ -566,15 +563,5 @@ class ASU_RFI_Form_Shortcodes extends Hook
     ), $redirectUrl);
 
     return $redirectUrl;
-  }
-
-  /**
-   * Filter callback for setting HTTP API request timeouts.
-   */
-  public function rfi_request_timeout($time)
-  {
-    // This works only if you don't set a timeout in the wp_remote_post() call itself
-
-    return 20;
   }
 }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -172,6 +172,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
     ensure_default($atts, 'semesters', null);
     ensure_default($atts, 'thank_you_page', '');
     ensure_default($atts, 'major_code_picker', 0);
+    ensure_defaults($atts, 'endpoint', 'prod');
 
     error_log('Creating view data...');
 
@@ -205,6 +206,13 @@ class ASU_RFI_Form_Shortcodes extends Hook
       $view_data['testmode'] = 'Test';
     } else {
       $view_data['testmode'] = 'Prod';
+    }
+
+    // sets the hidden form element 'endpoint', defaulting to 'Prod'
+    if (isset($atts['endpoint']) && 0 === strcasecmp('test', $atts['endpoint'])) {
+      $view_data['endpoint'] = 'Test';
+    } else {
+      $view_data['endpoint'] = 'Prod';
     }
 
     // Use the attribute source id over the sites option
@@ -284,7 +292,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
         $view_data['client_geo_location'] = Client_Geocoding_Service::client_geo_location();
       } else {
         error_log('error submitting ASU RFI (code: ' . $response_status_code . ') : ' . $message);
-        $view_data['error_message'] = $message ? 'Error: ' . $message : 'Something went wrong with your submission';
+        $view_data['error_message'] = $message ?'Error: ' . $message : 'Something went wrong with your submission';
       }
     }
     return $view_data;
@@ -342,7 +350,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
      * determine which endpoint to use (normal, or QA) based on value we set in a hidden field.
      * We only expect 'Test' or 'Prod', and use 'Prod' for any value except 'Test'
      */
-    switch ($_POST['testmode']) {
+    switch ($_POST['endpoint']) {
       case 'Test':
         $this->currentEndPoint = self::DEVELOPMENT_FORM_ENDPOINT;
         break;

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -182,13 +182,11 @@ class ASU_RFI_Form_Shortcodes extends Hook
       'major_code' => $atts['major_code']
     );
 
-    // sets the hidden form element 'testmode'. Using this to determine which endpoint to use, as well.
+    // sets the hidden form element 'testmode', defaulting to 'Prod'
     if (isset($atts['test_mode']) && 0 === strcasecmp('test', $atts['test_mode'])) {
       $view_data['testmode'] = 'Test';
-      $this->currentEndPoint = self::DEVELOPMENT_FORM_ENDPOINT;
     } else {
-      $view_data['testmode'] = 'Prod'; // default to production mode
-      $this->currentEndPoint = self::PRODUCTION_FORM_ENDPOINT;
+      $view_data['testmode'] = 'Prod';
     }
 
     // Use the attribute source id over the sites option
@@ -312,6 +310,19 @@ class ASU_RFI_Form_Shortcodes extends Hook
     unset($_POST['g-recaptcha-response']);
     unset($_POST['action']);
     unset($_POST['rfi-submit']);
+
+    /**
+     * determine which endpoint to use (normal, or QA) based on value we set in a hidden field.
+     * We only expect 'Test' or 'Prod', and use 'Prod' for any value except 'Test'
+     */
+    switch ($_POST['testmode']) {
+      case 'Test':
+        $this->currentEndPoint = self::DEVELOPMENT_FORM_ENDPOINT;
+        break;
+      case 'Prod':
+      default:
+        $this->currentEndPoint = self::PRODUCTION_FORM_ENDPOINT
+    }
 
     // submit the form (using the Wordpress HTTP API)
     $response = wp_remote_post(

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -524,8 +524,9 @@ class ASU_RFI_Form_Shortcodes extends Hook
     return $redirectUrl;
   }
 
-  public function rfi_request_timeout()
+  public function rfi_request_timeout($time)
   {
+    error_log('HTTP Timeout callback recieved time limit of: ' . $time . '. Setting to 20.');
     // not sure if setting this in wp_remote_post() is actually working. Trying this method.
     return 20;
   }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -349,6 +349,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
       $this->currentEndPoint,
       array(
         'body' => $_POST,
+        'timeout' => 20
       )
     );
     $end = time();

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -340,11 +340,15 @@ class ASU_RFI_Form_Shortcodes extends Hook
    */
   private function submit_form()
   {
-    error_log('Submitting form to ASU endpoint...');
-    // the actual form submission doesn't need our reCAPTCHA stuff
+    error_log('Entering submit_form() method...');
+
+    $thank_you_page = $_POST['thank_you'];
+
+    // the actual form submission doesn't need our special hidden fields
     unset($_POST['g-recaptcha-response']);
     unset($_POST['action']);
     unset($_POST['rfi-submit']);
+    unset($_POST['thank_you']);
 
     /**
      * determine which endpoint to use (normal, or QA) based on value we set in a hidden field.

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -470,7 +470,6 @@ class ASU_RFI_Form_Shortcodes extends Hook
         return new \WP_Error('recaptcha', 'Insufficient score reported by Google reCAPTCHA');
       }
     } else {
-      error_log('Result was ERROR. No reCAPTCHA score returned.');
       // we did NOT get a score. Gather the Google error(s) and return it/them.
       $my_error = new \WP_Error();
 
@@ -479,7 +478,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
       foreach ($result->{'error-codes'} as $thisError) {
         $my_error->add('recaptcha', ' Google reCAPTCHA reported ' . $thisError);
       }
-
+      error_log('Result was ERROR: ' . $my_error->get_error_message());
       return $my_error;
     }
   }

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -398,7 +398,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
      * If we get here, then there should have been no exceptions (and, therefore, no 400/500 errors).
      * As a last-chance sanity check, we make sure to show the user positive feedback ONLY when the
      * resulting status is a 200.
-     */ cd
+     */
     $statusCode = $response->getStatusCode();
 
     // return a URL on a 200, and a WP_Error on any other code

--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -47,6 +47,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
 
   public function define_hooks()
   {
+    error_log('Defining hooks...');
     $this->add_action('wp_enqueue_scripts', $this, 'wp_enqueue_scripts');
     $this->add_shortcode('asu-rfi-form', $this, 'asu_rfi_form');
     $this->add_action('init', $this, 'setup_rewrites');
@@ -111,6 +112,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
    */
   public function setup_rewrites()
   {
+    error_log('Setting up rewrite rules...');
     add_rewrite_tag('%statusFlag%', '([^&]+)');
     add_rewrite_tag('%msg%', '([^&]+)');
   }
@@ -121,6 +123,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
    */
   public function wp_enqueue_scripts()
   {
+    error_log('Enqueueing Scripts...');
     if ($this->current_page_has_rfi_shortcode()) {
       $url_to_css_file = plugin_dir_url(dirname(dirname(__FILE__))) . 'assets/css/asu-rfi.css';
       wp_enqueue_style($this->plugin_slug, $url_to_css_file, array(), $this->version);
@@ -395,7 +398,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
      * If we get here, then there should have been no exceptions (and, therefore, no 400/500 errors).
      * As a last-chance sanity check, we make sure to show the user positive feedback ONLY when the
      * resulting status is a 200.
-     */
+     */ cd
     $statusCode = $response->getStatusCode();
 
     // return a URL on a 200, and a WP_Error on any other code
@@ -516,7 +519,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
    */
   private function redirect_with_error($error, $url)
   {
-
+    error_log('Using redirect_with_error() on ' . $url);
     // clean up the URL
     $location = esc_url_raw($url);
 

--- a/src/views/rfi-form/form-javascript.handlebars
+++ b/src/views/rfi-form/form-javascript.handlebars
@@ -1,6 +1,6 @@
 <script>
   $(function() {
-    $('#registrationForm').validate();
+    //$('#registrationForm').validate();
 
     if ($('input[name="degreeLevel"]').val() == 'grad') {
       $('#poiCode').change(function() {

--- a/src/views/rfi-form/recaptcha-javascript.handlebars
+++ b/src/views/rfi-form/recaptcha-javascript.handlebars
@@ -24,18 +24,22 @@
     $('.asu-rfi-form').submit(function (e) {
         // see if we've already put a token in there
         currentToken = $.trim($('#g-recaptcha-response').val());
+        tokenCheck = $('#token-check').val();
 
-        if (currentToken.length != 0) {
-            // already have a token, so go ahead and try the submit
+        if (currentToken.length != 0 && 'check' == tokenCheck) {
+            // already have a token, and our check, so go ahead and try the submit
             return;
         } else {
-            // if nothing is there, call out to Google for a reCAPTCHA token
+            // if nothing is there, or our check field is not set to 'check',
+            // get a new token. This prevents us from using stale tokens set by
+            // ContactForm7 on page load
             e.preventDefault();
+            $('#g-recaptcha-response').val('');
             grecaptcha.execute('{{ site_key }}', { action: 'rfi' }).then(function (token) {
-                var d = new Date();
                 $('#g-recaptcha-response').val(token);
+                $('#token-check').val('check');
                 // submit the form. This WILL trigger our submit() method again, which
-                // is why we test for an existing key above - or we'll create an infinite loop
+                // is why we test for a token/check above - or we'll create an infinite loop
                 $('.asu-rfi-form').submit();
             });
         }

--- a/src/views/rfi-form/recaptcha-javascript.handlebars
+++ b/src/views/rfi-form/recaptcha-javascript.handlebars
@@ -1,8 +1,44 @@
 <script src="https://www.google.com/recaptcha/api.js?render={{ site_key }}"></script>
 <script>
     grecaptcha.ready(function () {
-        grecaptcha.execute('{{ site_key }}', { action: 'rfi' }).then(function (token) {
-            $('#g-recaptcha-response').val(token);
-        });
+        // disable the form if we are missing our site key, as we won't be able to get a
+        // reCAPTCHA token without it.
+        var siteKey = $.trim('{{ site_key }}');
+        console.log('Site key length: ' + siteKey.length);
+        if (0 === siteKey.length) {
+            $('.asu-rfi-form').before('<p class="alert alert-warning">We\'re sorry, but this form not currently available.</p>');
+            $('.asu-rfi-form').fadeTo(0.5, 0.25);
+            $('.asu-rfi-form input[type="submit"]').attr('disabled', 'disabled');
+        }
+    });
+
+    /**
+     * reCAPTCHA processing on form submit
+     */
+    $('.asu-rfi-form').submit(function (e) {
+        // check for an existing value in our hidden field.
+        currentToken = $.trim($('#g-recaptcha-response').val());
+        console.log('Current token = ' + currentToken);
+
+        if (currentToken.length != 0) {
+            // already have a token, so go ahead and try the submit
+            console.log('Existing token. Submitting form.');
+            return;
+        } else {
+            // if nothing is there, call out to Google for a reCAPTCHA token
+            e.preventDefault();
+            console.log('Getting token from Google...');
+            grecaptcha.execute('{{ site_key }}', { action: 'rfi' }).then(function (token) {
+                console.log("Token returned: " + token);
+                var d = new Date();
+                console.log('Received key at: ' + d);
+                console.log('Key length is: ' + token.length);
+                console.log(token);
+                $('#g-recaptcha-response').val(token);
+                // submit the form. This WILL trigger our submit() method again, which
+                // is why we test for an existing key above - or we'll create an infinite loop
+                $('.asu-rfi-form').submit();
+            });
+        }
     });
 </script>

--- a/src/views/rfi-form/recaptcha-javascript.handlebars
+++ b/src/views/rfi-form/recaptcha-javascript.handlebars
@@ -1,7 +1,7 @@
-<script src="https://www.google.com/recaptcha/api.js?render=6Ldlq40UAAAAAASePPra7bfEVU0Le5uDJzNRG_6j"></script>
+<script src="https://www.google.com/recaptcha/api.js?render={{ site_key }}"></script>
 <script>
     grecaptcha.ready(function () {
-        grecaptcha.execute('6Ldlq40UAAAAAASePPra7bfEVU0Le5uDJzNRG_6j', { action: 'rfi' }).then(function (token) {
+        grecaptcha.execute('{{ site_key }}', { action: 'rfi' }).then(function (token) {
             $('#g-recaptcha-response').val(token);
         });
     });

--- a/src/views/rfi-form/recaptcha-javascript.handlebars
+++ b/src/views/rfi-form/recaptcha-javascript.handlebars
@@ -4,36 +4,35 @@
         // disable the form if we are missing our site key, as we won't be able to get a
         // reCAPTCHA token without it.
         var siteKey = $.trim('{{ site_key }}');
-        console.log('Site key length: ' + siteKey.length);
         if (0 === siteKey.length) {
             $('.asu-rfi-form').before('<p class="alert alert-warning">We\'re sorry, but this form not currently available.</p>');
             $('.asu-rfi-form').fadeTo(0.5, 0.25);
             $('.asu-rfi-form input[type="submit"]').attr('disabled', 'disabled');
         }
+
+        $token = $.trim($('#g-recaptcha-response').val());
+        if (0 != $token.length) {
+            console.log('A token exists after page load. Removing.');
+            $('#g-recaptcha-response').val('');
+        }
+
     });
 
     /**
      * reCAPTCHA processing on form submit
      */
     $('.asu-rfi-form').submit(function (e) {
-        // check for an existing value in our hidden field.
+        // see if we've already put a token in there
         currentToken = $.trim($('#g-recaptcha-response').val());
-        console.log('Current token = ' + currentToken);
 
         if (currentToken.length != 0) {
             // already have a token, so go ahead and try the submit
-            console.log('Existing token. Submitting form.');
             return;
         } else {
             // if nothing is there, call out to Google for a reCAPTCHA token
             e.preventDefault();
-            console.log('Getting token from Google...');
             grecaptcha.execute('{{ site_key }}', { action: 'rfi' }).then(function (token) {
-                console.log("Token returned: " + token);
                 var d = new Date();
-                console.log('Received key at: ' + d);
-                console.log('Key length is: ' + token.length);
-                console.log(token);
                 $('#g-recaptcha-response').val(token);
                 // submit the form. This WILL trigger our submit() method again, which
                 // is why we test for an existing key above - or we'll create an infinite loop

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -17,6 +17,7 @@
 <form method="post" action="{{ form_endpoint }}" class="asu-rfi-form">
   <input type="hidden" name="degreeLevel" value="{{ degreeLevel }}">
   <input type="hidden" name="testmode" value="{{ testmode }}">
+  <input type="hidden" name="endpoint" value="{{ endpoint }}">
   <input type="hidden" name="thank_you" value="{{ thank_you }}">
   <input type="hidden" name="formUrl" value="{{ formUrl }}">
   <input type="hidden" name="source_id" value="{{ source_id }}">

--- a/src/views/rfi-form/simple-request-info-form.handlebars
+++ b/src/views/rfi-form/simple-request-info-form.handlebars
@@ -114,6 +114,7 @@
 
   <div class="form-group">
     <input type="submit" name="rfi-submit" value="Submit" class="btn btn-default" aria-label="Submit Request">
+    <input type="hidden" id="token-check" name="token-check" value="">
     <input type="hidden" id="g-recaptcha-response" name="g-recaptcha-response" value="" />
   </div>
 </form>


### PR DESCRIPTION
Multiple fixes and general cleanup, including:

* **Adding storage of the reCAPTCHA site key to the database**. Decided to use the WordPress options feature to store our public (aka 'site') key. Added a field to the RFI settings adming page, and updated the code to pull from the database when setting up the view variables.

* **Decouple endpoint and test mode**. I mistakenly thought that 'test_mode=test' would automatically use the QA endpoint. It turns out, however, that making a request to the live endpoint, with test mode set to "test" is totally legit. Added a short code attribute so that you can explicitly set both the endpoint and the test mode on every form, if you want.

* **Switch to GuzzleHTTP**. Using Guzzle, instead of the WordPress HTTP API, for both reCAPTCHA verification and submitting the RFI in an attempt to solve the timeout problems. Turns out that it was not the fault of the WordPress HTTP API, but Guzzle is nice - and seems to actually respect the timeout values that you set.
