### PR TITLE
Tell Travis-CI Not to Install Bower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ matrix:
 
 install:
   - composer install --no-interaction --prefer-source
-  - npm install -g bower
-  - bower install
+#  - npm install -g bower
+#  - bower install
+
 
 before_script:
   - bash bin/install-wp-tests.sh wordpress_test_asu_rfi root '' localhost $WP_VERSION


### PR DESCRIPTION
According to their own docs, Travis-CI will use Yarn if they see a yarn.lock file in your project root. I'm commenting out this bower install (which is failing because I removed the bower.json) file, and hoping Travis will automatically use Yarn.