### PR TITLE
Fix Boolean Logic Bug

### DIFF
--- a/src/shortcodes/asu-rfi-form-shortcodes.php
+++ b/src/shortcodes/asu-rfi-form-shortcodes.php
@@ -170,6 +170,9 @@ class ASU_RFI_Form_Shortcodes extends Hook
     ensure_default($atts, 'major_code_picker', 0);
     ensure_default($atts, 'endpoint', 'prod');
 
+    // make sure this true/false string becomes the proper boolean value
+    $atts['major_code_picker'] = filter_var( $atts['major_code_picker'], FILTER_VALIDATE_BOOLEAN);
+
     $view_data = array(
       'form_endpoint' => esc_url(admin_url('admin-post.php')), // since we're using callbacks on admin-post now
       'thank_you' => $atts['thank_you_page'],
@@ -233,7 +236,7 @@ class ASU_RFI_Form_Shortcodes extends Hook
 
       $view_data['college_program_code'] = $atts['college_program_code'];
 
-      if ($atts['major_code_picker']) {
+      if (TRUE === $atts['major_code_picker']) {
         $view_data['major_codes'] = ASUDegreeStore::get_programs(
           $atts['college_program_code'],
           $view_data['degreeLevel'],


### PR DESCRIPTION
We had a classic PHP bug here: 

* Accept the short-code attribute "false", which is a string
* Evaluate that string to see if we should create our Program of Interest list 
* PHP happily evaluates a non-empty string as TRUE
* We get a drop-down list 100% of the time

There is only one value (right now) that can fall prey to this issue, so I fixed it with a call to PHP's built-in filter_var() method and asked for the appropriate boolean value. Then, later, when we are deciding whether or not to compile our list, I explicitly require that 'major_code_picker' be a boolean TRUE.

This fixed the issue on my dev machine, preventing the drop-down list from being created, and still preserving the hidden POI field and it's value of "SUEMSLEMSL".

I'm not super familiar with the business logic here, and any ramifications of this change in that regard, but there clearly was a logic bug that should now be fixed.